### PR TITLE
Split Eclipse into explicit v1/v2 classes + best-of-both unifier (2.0.0)

### DIFF
--- a/docs/adr/0001-eclipse-v1-v2-class-split.md
+++ b/docs/adr/0001-eclipse-v1-v2-class-split.md
@@ -1,9 +1,16 @@
 # ADR 0001 — Split EclipseAPI into explicit v1 / v2 classes with a unifying "best of both" class
 
-- **Status:** Accepted
+- **Status:** Accepted — implemented in 2.0.0
 - **Date:** 2026-05-30
 - **Deciders:** Spencer Ogden
 - **Supersedes:** the single mixed `EclipseAPI` class (v1 methods + one v2 method)
+
+> **Implementation note (2.0.0):** Shipped as `EclipseBase` → `EclipseV1` / `EclipseV2`,
+> plus `Eclipse` (composition unifier: shared token, `.v1`/`.v2`, `__getattr__`-delegates
+> the v1 long tail to `self.v1`, overrides `get_set_asides` to `self.v2`). `EclipseAPI` is
+> a `DeprecationWarning` subclass of `Eclipse`. The unifier uses `__getattr__` forwarding
+> rather than hand-listing ~60 delegations — a deliberate, lower-maintenance realization of
+> the "pure composition" decision (still composition; `.v1`/`.v2` remain explicit).
 
 ## Context
 

--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,9 +1,10 @@
-__version__ = "1.12.0"
+__version__ = "2.0.0"
 
 import logging
 import re
 import threading
 import time
+import warnings
 from pathlib import Path
 from urllib.parse import urlencode
 
@@ -2076,10 +2077,14 @@ class OrionAPI(BaseAPI):
         return res.json()
 
 
-class EclipseAPI(BaseAPI):
-    """Client for the Eclipse Trading Platform API.
+class EclipseBase(BaseAPI):
+    """Shared base for the Eclipse Trading Platform API clients.
 
-    Provides access to accounts, portfolios, models, orders, and trade tools.
+    Holds authentication, the v1/v2 base URLs, account-id resolution helpers
+    (which some v2 operations rely on), and the generic ``eclipse_request``
+    escape hatch. Concrete surfaces are provided by :class:`EclipseV1` and
+    :class:`EclipseV2`; :class:`Eclipse` composes both. Not normally constructed
+    directly.
 
     Instances are safe to share across threads after ``login()``. Token
     reads/writes and the rate limiter are serialized internally.
@@ -2088,18 +2093,23 @@ class EclipseAPI(BaseAPI):
         usr: Username for authentication
         pwd: Password for authentication
         orion_token: Orion session token (alternative to usr/pwd)
+        eclipse_token: An already-minted Eclipse session token to use directly,
+            skipping the login round-trip (used by :class:`Eclipse` to share one
+            token across its v1/v2 sub-clients). Takes precedence over usr/pwd.
         rate_limit: Maximum API calls per second (default 10, set to 0 to disable)
         verify_ssl: Verify SSL certificates (default True)
         ca_bundle: Path to custom CA bundle file (optional)
-
-    Example:
-        >>> api = EclipseAPI(usr="user@example.com", pwd="password")
-        >>> api.check_username()
-        'user@example.com'
     """
 
     def __init__(
-        self, usr=None, pwd=None, orion_token=None, rate_limit=10, verify_ssl=True, ca_bundle=None
+        self,
+        usr=None,
+        pwd=None,
+        orion_token=None,
+        eclipse_token=None,
+        rate_limit=10,
+        verify_ssl=True,
+        ca_bundle=None,
     ):
         super().__init__(rate_limit=rate_limit, verify_ssl=verify_ssl, ca_bundle=ca_bundle)
         self.eclipse_token = None
@@ -2109,7 +2119,10 @@ class EclipseAPI(BaseAPI):
         # Eclipse answers with a misleading 403 "missing privileges" error.
         self.base_url_v2 = "https://api.orioneclipse.com/api/v2"
 
-        if usr is not None:
+        if eclipse_token is not None:
+            # Use a pre-minted token directly (no network round-trip).
+            self.eclipse_token = eclipse_token
+        elif usr is not None:
             self.login(usr, pwd)
             # Credentials are not stored to prevent memory exposure
         elif orion_token is not None:
@@ -2201,15 +2214,6 @@ class EclipseAPI(BaseAPI):
         res = self.api_request(f"{base}{path}", req_func, **kwargs)
         return res.json()
 
-    def check_username(self):
-        """Get the authenticated user's login ID.
-
-        Returns:
-            str: The user's login ID
-        """
-        res = self.api_request(f"{self.base_url}/admin/authorization/user")
-        return res.json()["userLoginId"]
-
     def get_all_accounts(self):
         """Get a simplified list of all accounts.
 
@@ -2218,68 +2222,6 @@ class EclipseAPI(BaseAPI):
         """
         res = self.api_request(f"{self.base_url}/account/accounts/simple")
         return res.json()
-
-    def _normalize_set_aside(self, record):
-        """Augment a raw v2 set-aside record with normalized snake_case fields.
-
-        The original Eclipse keys are preserved; the normalized keys provide a
-        stable contract (e.g. ``set_aside_id``, ``amount``) regardless of the
-        upstream field spellings.
-
-        Args:
-            record: A raw AccountSetAsideCashResponseDto dict
-
-        Returns:
-            dict: The record with normalized keys added
-        """
-        expiration_type_id = record.get("expirationTypeId")
-        end_date = record.get("expirationValue") if expiration_type_id == EXPIRE_TYPE_DATE else None
-        return {
-            **record,
-            "set_aside_id": record.get("id"),
-            "account_id": record.get("accountId"),
-            "account_number": record.get("accountNumber"),
-            "amount": record.get("setAsideCashAmount"),
-            "active": record.get("isActive"),
-            "description": record.get("description"),
-            "start_date": record.get("startDate"),
-            "end_date": end_date,
-        }
-
-    def get_set_asides(self, account_id=None, active_only=False):
-        """Get set-aside cash reservations, including the Eclipse set-aside id.
-
-        Uses the v2 batch endpoint, which accepts a list of internal account IDs
-        and returns one record per set-aside (each carrying its own ``id``,
-        ``accountId``, and ``accountNumber``). Records are augmented with
-        normalized snake_case fields (``set_aside_id``, ``amount``, ``active``,
-        ``account_number``, ``description``, ``start_date``, ``end_date``); the
-        original Eclipse keys are preserved.
-
-        Args:
-            account_id: Account ID, number, or name to restrict to a single
-                account. When None (default), returns set-asides firm-wide by
-                issuing one batch POST over all accounts.
-            active_only: When True, return only currently-active set-asides.
-                Defaults to False (includes expired/inactive).
-
-        Returns:
-            list: Augmented set-aside records
-        """
-        if account_id is not None:
-            account_ids = [self.get_internal_account_id(account_id)]
-        else:
-            account_ids = [a["id"] for a in self.get_all_accounts()]
-
-        res = self.api_request(
-            f"{self.base_url_v2}/Account/Accounts/SetAsideCashSettings",
-            requests.post,
-            json=account_ids,
-        )
-        records = [self._normalize_set_aside(r) for r in res.json()]
-        if active_only:
-            records = [r for r in records if r.get("active")]
-        return records
 
     def get_internal_account_id(self, search_param):
         """Get internal Eclipse account ID from a search parameter.
@@ -2368,6 +2310,60 @@ class EclipseAPI(BaseAPI):
             ),
         )
         return best_acct["id"], best_acct["accountNumber"]
+
+
+class EclipseV1(EclipseBase):
+    """Eclipse client targeting the v1 API surface (``/v1/...``) only.
+
+    Every method here calls a ``/v1`` endpoint, so callers always know which
+    surface they are hitting. For the newer ``/api/v2`` surface use
+    :class:`EclipseV2`, or :class:`Eclipse` for a best-of-both client.
+
+    Args:
+        usr: Username for authentication
+        pwd: Password for authentication
+        orion_token: Orion session token (alternative to usr/pwd)
+        rate_limit: Maximum API calls per second (default 10, set to 0 to disable)
+        verify_ssl: Verify SSL certificates (default True)
+        ca_bundle: Path to custom CA bundle file (optional)
+
+    Example:
+        >>> api = EclipseV1(usr="user@example.com", pwd="password")
+        >>> api.check_username()
+        'user@example.com'
+    """
+
+    def check_username(self):
+        """Get the authenticated user's login ID.
+
+        Returns:
+            str: The user's login ID
+        """
+        res = self.api_request(f"{self.base_url}/admin/authorization/user")
+        return res.json()["userLoginId"]
+
+    def get_set_asides(self, account_id, active_only=False):
+        """Get set-aside cash settings for a specific account (v1 surface).
+
+        Returns the raw v1 records from ``GET /account/accounts/{id}/asidecash``.
+        For firm-wide set-asides or normalized fields (including the authoritative
+        Eclipse set-aside id), use :meth:`EclipseV2.get_set_asides` or the
+        :class:`Eclipse` unifier.
+
+        Args:
+            account_id: Account ID, number, or name (resolved via search).
+            active_only: When True, keep only records where ``isActive`` is truthy.
+                Defaults to False (includes expired/inactive).
+
+        Returns:
+            list: Raw v1 set-aside records for the account.
+        """
+        internal_id = self.get_internal_account_id(account_id)
+        res = self.api_request(f"{self.base_url}/account/accounts/{internal_id}/asidecash")
+        records = res.json()
+        if active_only:
+            records = [r for r in records if r.get("isActive")]
+        return records
 
     def create_set_aside(
         self,
@@ -3963,3 +3959,169 @@ class EclipseAPI(BaseAPI):
         result = res.json()
         self._maybe_wait_for_analytics(sync)
         return result
+
+
+class EclipseV2(EclipseBase):
+    """Eclipse client targeting the v2 API surface (``/api/v2/...``) only.
+
+    The v2 surface is newer and broader but does not cover everything v1 does
+    (e.g. holdings and authorization/user have no v2 equivalent). Methods here
+    call ``/api/v2`` endpoints explicitly. For the full v1 surface use
+    :class:`EclipseV1`, or :class:`Eclipse` for a best-of-both client. The
+    generic :meth:`eclipse_request` (inherited) reaches any un-wrapped v2 path.
+
+    Account-id resolution helpers are inherited from :class:`EclipseBase`
+    because some v2 calls (e.g. the set-aside batch) need internal account ids,
+    which are sourced from the v1 account search.
+    """
+
+    def _normalize_set_aside(self, record):
+        """Augment a raw v2 set-aside record with normalized snake_case fields.
+
+        The original Eclipse keys are preserved; the normalized keys provide a
+        stable contract (e.g. ``set_aside_id``, ``amount``) regardless of the
+        upstream field spellings.
+
+        Args:
+            record: A raw AccountSetAsideCashResponseDto dict
+
+        Returns:
+            dict: The record with normalized keys added
+        """
+        expiration_type_id = record.get("expirationTypeId")
+        end_date = record.get("expirationValue") if expiration_type_id == EXPIRE_TYPE_DATE else None
+        return {
+            **record,
+            "set_aside_id": record.get("id"),
+            "account_id": record.get("accountId"),
+            "account_number": record.get("accountNumber"),
+            "amount": record.get("setAsideCashAmount"),
+            "active": record.get("isActive"),
+            "description": record.get("description"),
+            "start_date": record.get("startDate"),
+            "end_date": end_date,
+        }
+
+    def get_set_asides(self, account_id=None, active_only=False):
+        """Get set-aside cash reservations, including the Eclipse set-aside id.
+
+        Uses the v2 batch endpoint, which accepts a list of internal account IDs
+        and returns one record per set-aside (each carrying its own ``id``,
+        ``accountId``, and ``accountNumber``). Records are augmented with
+        normalized snake_case fields (``set_aside_id``, ``amount``, ``active``,
+        ``account_number``, ``description``, ``start_date``, ``end_date``); the
+        original Eclipse keys are preserved.
+
+        Args:
+            account_id: Account ID, number, or name to restrict to a single
+                account. When None (default), returns set-asides firm-wide by
+                issuing one batch POST over all accounts.
+            active_only: When True, return only currently-active set-asides.
+                Defaults to False (includes expired/inactive).
+
+        Returns:
+            list: Augmented set-aside records
+        """
+        if account_id is not None:
+            account_ids = [self.get_internal_account_id(account_id)]
+        else:
+            account_ids = [a["id"] for a in self.get_all_accounts()]
+
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/SetAsideCashSettings",
+            requests.post,
+            json=account_ids,
+        )
+        records = [self._normalize_set_aside(r) for r in res.json()]
+        if active_only:
+            records = [r for r in records if r.get("active")]
+        return records
+
+
+class Eclipse(EclipseBase):
+    """Best-of-both Eclipse client composing :class:`EclipseV1` and :class:`EclipseV2`.
+
+    Authenticates once and shares the single Eclipse token with both sub-clients,
+    exposed as ``.v1`` and ``.v2`` so the version you are hitting is always
+    explicit. Unknown attributes delegate to the complete v1 surface; methods
+    that v2 serves better are overridden here to use ``.v2``. Each overridden
+    method's docstring names the surface it uses.
+
+    Example:
+        >>> api = Eclipse(usr="user@example.com", pwd="password")
+        >>> api.get_set_asides()        # firm-wide, via v2 (best)
+        >>> api.get_account_holdings(1)  # via v1 (no v2 equivalent)
+        >>> api.v2.get_set_asides(1114)  # explicit v2
+        >>> api.v1.get_set_asides(1114)  # explicit v1 (raw per-account)
+    """
+
+    def __init__(
+        self,
+        usr=None,
+        pwd=None,
+        orion_token=None,
+        eclipse_token=None,
+        rate_limit=10,
+        verify_ssl=True,
+        ca_bundle=None,
+    ):
+        super().__init__(
+            usr=usr,
+            pwd=pwd,
+            orion_token=orion_token,
+            eclipse_token=eclipse_token,
+            rate_limit=rate_limit,
+            verify_ssl=verify_ssl,
+            ca_bundle=ca_bundle,
+        )
+        # Share the single authenticated token with both sub-clients (no re-login).
+        sub_kwargs = {
+            "eclipse_token": self.eclipse_token,
+            "rate_limit": rate_limit,
+            "verify_ssl": verify_ssl,
+            "ca_bundle": ca_bundle,
+        }
+        self.v1 = EclipseV1(**sub_kwargs)
+        self.v2 = EclipseV2(**sub_kwargs)
+
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the complete v1 surface.
+
+        Only invoked for attributes not found normally (i.e. not defined on
+        Eclipse/EclipseBase). Guarded so attribute access during __init__ — before
+        ``self.v1`` exists — raises AttributeError instead of recursing.
+        """
+        try:
+            v1 = self.__dict__["v1"]
+        except KeyError as e:
+            raise AttributeError(name) from e
+        return getattr(v1, name)
+
+    # --- v2-preferred overrides (documented best-of-both choices) ---------------
+
+    def get_set_asides(self, account_id=None, active_only=False):
+        """Set-asides via the v2 batch endpoint (best: firm-wide + set-aside id).
+
+        Delegates to :meth:`EclipseV2.get_set_asides`. Use ``self.v1.get_set_asides``
+        for the raw per-account v1 form.
+        """
+        return self.v2.get_set_asides(account_id=account_id, active_only=active_only)
+
+
+class EclipseAPI(Eclipse):
+    """Deprecated alias of :class:`Eclipse` (best-of-both client).
+
+    Retained for backwards compatibility with pre-2.0 callers. Prefer
+    :class:`Eclipse`, or :class:`EclipseV1` / :class:`EclipseV2` to target a
+    specific API surface explicitly. Emits a ``DeprecationWarning`` on
+    construction and will be removed in a future major release.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "EclipseAPI is deprecated; use Eclipse (best of v1+v2), or "
+            "EclipseV1 / EclipseV2 to target a surface explicitly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "1.12.0"
+version = "2.0.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ def eclipse_credentials():
 
 @pytest.fixture
 def eclipse_client(eclipse_credentials):
-    """Return authenticated EclipseAPI client."""
-    from orionapi import EclipseAPI
+    """Return authenticated Eclipse client (best-of-both v1/v2 unifier)."""
+    from orionapi import Eclipse
 
-    return EclipseAPI(**eclipse_credentials)
+    return Eclipse(**eclipse_credentials)
 
 
 @pytest.fixture

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from orionapi import EclipseAPI, OrionAPI
+from orionapi import EclipseAPI, EclipseV1, EclipseV2, OrionAPI
 
 
 class TestOrionUpdateOperations:
@@ -82,7 +82,7 @@ class TestOrionUpdateOperations:
                 assert result["accountType"] == "IRA"
 
 
-# EclipseAPI doesn't have update operations yet, removed invalid test
+# EclipseV1 doesn't have update operations yet, removed invalid test
 
 
 class TestEclipseAnalytics:
@@ -90,8 +90,8 @@ class TestEclipseAnalytics:
 
     def test_get_analytics_status_running(self):
         """Test getting analytics status when running."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             # Mock api_request to return status
             with patch.object(api, "api_request") as mock_api_request:
@@ -107,8 +107,8 @@ class TestEclipseAnalytics:
 
     def test_get_analytics_status_complete(self):
         """Test getting analytics status when complete."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             # Mock api_request to return status
             with patch.object(api, "api_request") as mock_api_request:
@@ -123,8 +123,8 @@ class TestEclipseAnalytics:
 
     def test_run_analytics(self):
         """Test triggering analytics run."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             # Mock api_request to return status
             with patch.object(api, "api_request") as mock_api_request:
@@ -140,10 +140,10 @@ class TestEclipseAnalytics:
     def test_wait_for_analytics_immediate_completion(self):
         """Test wait_for_analytics when already complete."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(
                 api, "get_analytics_status", return_value={"isAnalysisRunning": False}
@@ -158,10 +158,10 @@ class TestEclipseAnalytics:
     def test_wait_for_analytics_polls_until_complete(self):
         """Test wait_for_analytics polls until complete."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             # Simulate analytics completing after 2 polls
             call_count = [0]
@@ -182,10 +182,10 @@ class TestEclipseAnalytics:
     def test_wait_for_analytics_timeout(self):
         """Test wait_for_analytics raises TimeoutError."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(
                 api, "get_analytics_status", return_value={"isAnalysisRunning": True}
@@ -196,10 +196,10 @@ class TestEclipseAnalytics:
     def test_maybe_wait_for_analytics_when_sync_true(self):
         """Test _maybe_wait_for_analytics waits when sync=True."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "wait_for_analytics", return_value=True) as mock_wait:
                 api._maybe_wait_for_analytics(sync=True)
@@ -209,10 +209,10 @@ class TestEclipseAnalytics:
     def test_maybe_wait_for_analytics_when_sync_false(self):
         """Test _maybe_wait_for_analytics skips when sync=False."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "wait_for_analytics", return_value=True) as mock_wait:
                 api._maybe_wait_for_analytics(sync=False)
@@ -226,12 +226,12 @@ class TestCreateSetAsideExtended:
     def test_create_set_aside_with_description(self):
         """Test create_set_aside with description."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "get_internal_account_id", return_value=123),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
-            patch.object(EclipseAPI, "_maybe_wait_for_analytics"),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "get_internal_account_id", return_value=123),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch("requests.post") as mock_post:
                 mock_response = Mock()
@@ -258,12 +258,12 @@ class TestCreateSetAsideExtended:
     def test_create_set_aside_percentage_type(self):
         """Test create_set_aside with percentage cash type."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "get_internal_account_id", return_value=123),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
-            patch.object(EclipseAPI, "_maybe_wait_for_analytics"),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "get_internal_account_id", return_value=123),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch("requests.post") as mock_post:
                 mock_response = Mock()
@@ -285,12 +285,12 @@ class TestCreateSetAsideExtended:
     def test_create_set_aside_date_expiration(self):
         """Test create_set_aside with date-based expiration."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "get_internal_account_id", return_value=123),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
-            patch.object(EclipseAPI, "_maybe_wait_for_analytics"),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "get_internal_account_id", return_value=123),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch("requests.post") as mock_post:
                 mock_response = Mock()
@@ -314,11 +314,11 @@ class TestCreateSetAsideExtended:
     def test_create_set_aside_no_sync(self):
         """Test create_set_aside with sync=False."""
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "get_internal_account_id", return_value=123),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "get_internal_account_id", return_value=123),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with (
                 patch("requests.post") as mock_post,
@@ -354,9 +354,9 @@ SAMPLE_SET_ASIDE = {
 
 
 def _eclipse_for_set_asides():
-    """Construct an EclipseAPI with auth/login patched out for unit tests."""
-    with patch.object(EclipseAPI, "login"):
-        api = EclipseAPI(usr="test", pwd="pass")
+    """Construct an EclipseV2 with auth/login patched out for unit tests."""
+    with patch.object(EclipseV2, "login"):
+        api = EclipseV2(usr="test", pwd="pass")
     # Provide a token so the real _get_auth_header succeeds during requests.
     api.eclipse_token = "test-token"
     return api
@@ -488,3 +488,36 @@ class TestEclipseRequest:
             api.eclipse_request("x", version="v3")
         with pytest.raises(ValueError, match="method must be"):
             api.eclipse_request("x", method="patch")
+
+
+class TestEclipseUnifierAndAlias:
+    """The Eclipse unifier composes v1/v2; EclipseAPI is a deprecated alias."""
+
+    def test_unifier_shares_token_and_exposes_subclients(self):
+        """Eclipse injects its token into .v1 / .v2 without re-logging in."""
+        from orionapi import Eclipse
+
+        api = Eclipse(eclipse_token="tok")
+        assert api.eclipse_token == "tok"
+        assert api.v1.eclipse_token == "tok"
+        assert api.v2.eclipse_token == "tok"
+        assert isinstance(api.v1, EclipseV1)
+        assert isinstance(api.v2, EclipseV2)
+
+    def test_unifier_delegates_v1_and_prefers_v2_for_set_asides(self):
+        """Unknown attrs delegate to v1; get_set_asides is overridden to use v2."""
+        from orionapi import Eclipse
+
+        api = Eclipse(eclipse_token="tok")
+        # delegated v1 method is bound to the v1 sub-client
+        assert api.create_set_aside.__self__ is api.v1
+        # get_set_asides is the unifier's own override (routes to v2)
+        assert api.get_set_asides.__self__ is api
+
+    def test_eclipse_api_alias_warns_and_constructs(self):
+        """EclipseAPI emits DeprecationWarning and still builds the unifier."""
+        with pytest.warns(DeprecationWarning, match="EclipseAPI is deprecated"):
+            api = EclipseAPI(eclipse_token="tok")
+        assert isinstance(api, EclipseAPI)
+        assert api.eclipse_token == "tok"
+        assert api.v1.eclipse_token == "tok"

--- a/tests/test_new_endpoints.py
+++ b/tests/test_new_endpoints.py
@@ -1,13 +1,13 @@
 """Unit tests for newly added API endpoints.
 
-Tests for OrionAPI and EclipseAPI methods added in v1.4.0.
+Tests for OrionAPI and EclipseV1 methods added in v1.4.0.
 """
 
 from unittest.mock import Mock, patch
 
 import pytest
 
-from orionapi import EclipseAPI, OrionAPI, OrionAPIError
+from orionapi import EclipseV1, OrionAPI, OrionAPIError
 
 
 class TestOrionAssets:
@@ -228,12 +228,12 @@ class TestOrionReporting:
 
 
 class TestEclipseTrades:
-    """Test EclipseAPI trade methods."""
+    """Test EclipseV1 trade methods."""
 
     def test_get_trade_status(self):
         """Test getting trade status."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "api_request") as mock_api_request:
                 mock_response = Mock()
@@ -253,16 +253,16 @@ class TestEclipseTrades:
 
     def test_get_trade_status_invalid_id(self):
         """Test get_trade_status with invalid ID."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="trade_id must be a positive integer"):
                 api.get_trade_status(trade_id=0)
 
     def test_get_trade_instance(self):
         """Test getting trade instance details."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "api_request") as mock_api_request:
                 mock_response = Mock()
@@ -287,16 +287,16 @@ class TestEclipseTrades:
 
     def test_get_trade_instance_invalid_id(self):
         """Test get_trade_instance with invalid ID."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="instance_id must be a positive integer"):
                 api.get_trade_instance(instance_id=0)
 
     def test_get_trade_instance_logs(self):
         """Test getting trade instance logs."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "api_request") as mock_api_request:
                 mock_response = Mock()
@@ -322,16 +322,16 @@ class TestEclipseTrades:
 
     def test_get_trade_instance_logs_invalid_id(self):
         """Test get_trade_instance_logs with invalid ID."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="instance_id must be a positive integer"):
                 api.get_trade_instance_logs(instance_id=-1)
 
     def test_get_trade_log_detail(self):
         """Test getting detailed HTML trade log."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "api_request") as mock_api_request:
                 import base64
@@ -360,16 +360,16 @@ class TestEclipseTrades:
 
     def test_get_trade_log_detail_invalid_id(self):
         """Test get_trade_log_detail with invalid ID."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="log_id must be a positive integer"):
                 api.get_trade_log_detail(log_id=0)
 
     def test_get_portfolio_trade_instances(self):
         """Test getting trade instances for a portfolio."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "api_request") as mock_api_request:
                 mock_response = Mock()
@@ -405,8 +405,8 @@ class TestEclipseTrades:
 
     def test_get_portfolio_trade_instances_invalid_params(self):
         """Test get_portfolio_trade_instances with invalid parameters."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="portfolio_id must be a positive integer"):
                 api.get_portfolio_trade_instances(
@@ -425,12 +425,12 @@ class TestEclipseTrades:
 
 
 class TestEclipseSecurityPreferences:
-    """Test EclipseAPI security preferences methods."""
+    """Test EclipseV1 security preferences methods."""
 
     def test_get_security_preferences(self):
         """Test getting security preferences."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch.object(api, "api_request") as mock_api_request:
                 mock_response = Mock()
@@ -455,8 +455,8 @@ class TestEclipseSecurityPreferences:
 
     def test_get_security_preferences_invalid_params(self):
         """Test get_security_preferences with invalid parameters."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="portfolio_id must be a positive integer"):
                 api.get_security_preferences(portfolio_id=0, security_id=1)
@@ -466,12 +466,12 @@ class TestEclipseSecurityPreferences:
 
 
 class TestEclipseTradeRestrictions:
-    """Test EclipseAPI trade restriction methods."""
+    """Test EclipseV1 trade restriction methods."""
 
     def test_set_portfolio_tradeable_block(self):
         """Test blocking portfolio trading."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             # Mock get_portfolio to return current portfolio state
             with (
@@ -501,8 +501,8 @@ class TestEclipseTradeRestrictions:
 
     def test_set_account_tradeable_block_advisor(self):
         """Test blocking advisor trading for an account."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with (
                 patch.object(api, "get_account_details") as mock_get,
@@ -534,20 +534,20 @@ class TestEclipseTradeRestrictions:
 
     def test_set_account_tradeable_invalid_restriction(self):
         """Test set_account_tradeable with invalid restriction."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(ValueError, match="trade_restriction must be one of"):
                 api.set_account_tradeable(account_id=123, trade_restriction="invalid")
 
 
 class TestEclipseTradeTools:
-    """Test EclipseAPI trade tool methods."""
+    """Test EclipseV1 trade tool methods."""
 
     def test_spend_cash_trade(self):
         """Test generating Spend Cash trade."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with (
                 patch.object(api, "api_request") as mock_api_request,

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -10,7 +10,7 @@ import pytest
 
 from orionapi import (
     AuthenticationError,
-    EclipseAPI,
+    EclipseV1,
     NotFoundError,
     OrionAPI,
     OrionAPIError,
@@ -37,9 +37,9 @@ class TestCredentialSecurity:
             assert "pwd" not in api.__dict__
 
     def test_eclipse_credentials_not_stored(self):
-        """Verify EclipseAPI doesn't store plaintext credentials."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="testuser", pwd="testpass")
+        """Verify EclipseV1 doesn't store plaintext credentials."""
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="testuser", pwd="testpass")
 
             # Credentials should NOT be stored
             assert not hasattr(api, "usr")
@@ -280,7 +280,7 @@ class TestAuthenticationErrors:
                 OrionAPI(usr="bad", pwd="wrong")
 
     def test_eclipse_login_403_error(self):
-        """Test EclipseAPI raises AuthenticationError on 403."""
+        """Test EclipseV1 raises AuthenticationError on 403."""
         with patch("requests.get") as mock_get:
             mock_response = Mock()
             mock_response.ok = False
@@ -290,7 +290,7 @@ class TestAuthenticationErrors:
             mock_get.return_value = mock_response
 
             with pytest.raises(AuthenticationError, match="Login failed"):
-                EclipseAPI(usr="bad", pwd="wrong")
+                EclipseV1(usr="bad", pwd="wrong")
 
     def test_token_extraction_error(self):
         """Test error when token is missing from response."""
@@ -426,8 +426,8 @@ class TestFilePathValidation:
 
     def test_parse_security_set_file_not_found(self):
         """Test parse_security_set_file rejects non-existent file."""
-        with patch.object(EclipseAPI, "login"):
-            api = EclipseAPI(usr="test", pwd="pass")
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(FileNotFoundError, match="File not found"):
                 api.parse_security_set_file("/nonexistent/path/file.txt")
@@ -435,12 +435,12 @@ class TestFilePathValidation:
     def test_export_security_set_invalid_parent_directory(self):
         """Test export rejects path with non-existent parent directory."""
         with (
-            patch.object(EclipseAPI, "login"),
+            patch.object(EclipseV1, "login"),
             patch.object(
-                EclipseAPI, "get_security_set", return_value={"name": "Test", "securities": []}
+                EclipseV1, "get_security_set", return_value={"name": "Test", "securities": []}
             ),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with pytest.raises(FileNotFoundError, match="Parent directory does not exist"):
                 api.export_security_set_to_file(123, "/nonexistent/dir/file.txt")
@@ -456,12 +456,12 @@ class TestBugFixes:
         Fix: Changed defaults from None to 0.0
         """
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "get_internal_account_id", return_value=123),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
-            patch.object(EclipseAPI, "_maybe_wait_for_analytics"),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "get_internal_account_id", return_value=123),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch("requests.post") as mock_post:
                 mock_response = Mock()
@@ -488,12 +488,12 @@ class TestBugFixes:
         Fix: Changed to use expire_trans_tol
         """
         with (
-            patch.object(EclipseAPI, "login"),
-            patch.object(EclipseAPI, "get_internal_account_id", return_value=123),
-            patch.object(EclipseAPI, "_get_auth_header", return_value={}),
-            patch.object(EclipseAPI, "_maybe_wait_for_analytics"),
+            patch.object(EclipseV1, "login"),
+            patch.object(EclipseV1, "get_internal_account_id", return_value=123),
+            patch.object(EclipseV1, "_get_auth_header", return_value={}),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
         ):
-            api = EclipseAPI(usr="test", pwd="pass")
+            api = EclipseV1(usr="test", pwd="pass")
 
             with patch("requests.post") as mock_post:
                 mock_response = Mock()

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from orionapi import AuthenticationError, EclipseAPI, OrionAPI, RateLimiter
+from orionapi import AuthenticationError, Eclipse, OrionAPI, RateLimiter
 
 
 class TestRateLimiterThreadSafety:
@@ -98,6 +98,6 @@ class TestAuthHeaderWithoutLogin:
             api._get_auth_header()
 
     def test_eclipse_raises_when_not_logged_in(self):
-        api = EclipseAPI()
+        api = Eclipse()
         with pytest.raises(AuthenticationError):
             api._get_auth_header()


### PR DESCRIPTION
Implements [ADR 0001](docs/adr/0001-eclipse-v1-v2-class-split.md). Replaces the single mixed `EclipseAPI` class with an explicit hierarchy so callers always know which Eclipse API surface they're hitting.

## What changed
```
BaseAPI
  └─ EclipseBase   # auth, base_url + base_url_v2, account-id resolution,
                   #   eclipse_request() escape hatch
       ├─ EclipseV1   # every /v1 endpoint (incl. raw per-account get_set_asides)
       ├─ EclipseV2   # /api/v2 endpoints (batch get_set_asides + normalization)
       └─ Eclipse     # best-of-both unifier (pure composition)
```
- **`Eclipse`** authenticates once and shares the token with `.v1` / `.v2` (both exposed for explicit access). Unknown attributes delegate to the complete v1 surface via `__getattr__`; `get_set_asides` is overridden to use v2 (firm-wide + authoritative set-aside id).
- **`EclipseAPI`** becomes a `DeprecationWarning` subclass of `Eclipse` — existing imports keep working and behavior (including the 1.11/1.12 v2 `get_set_asides`) is preserved. To be removed in a future major.
- **Tests** repointed to concrete classes (v1-method tests → `EclipseV1`, set-aside tests → `EclipseV2`); added unifier + alias tests; `conftest`/thread-safety use `Eclipse`.

## Coverage reality (why v1 stays)
`holdings` and `authorization/user` have **no v2 equivalent**, so v1 remains the backbone; v2 is adopted per-endpoint where it's strictly better. The `eclipse_request()` escape hatch (added in 1.12.0) reaches the ~400-path v2 long tail.

## ⚠️ Breaking change — 2.0.0
Canonical class names change and `EclipseAPI` is deprecated. Consumers should migrate to `Eclipse` (or `EclipseV1`/`EclipseV2`). **Bump to 2.0 with care.**

## Verification
- `ruff check` + `ruff format` clean.
- Full suite **280 passed, 10 skipped** (incl. live integration on the `Eclipse` fixture).
- `-W error::DeprecationWarning` on the unit suite passes (only the intentional alias test warns, caught by `pytest.warns`).

## Follow-ups (not in this PR)
- Grow `EclipseV2` with verified high-value endpoints (accounts, models, security sets, trade orders, analytics), each validated live.
- Untracked `API Docs/`, `PRD_*.md`, `RESUME.md` left out of git (large/working files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)