### PR TITLE
Ignore local API-doc blobs and working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ EclipseAPIDocs.html
 htmlcov/
 
 prod_-_CLI_Quickstart-oauth-credentials.txt
+
+# Local API reference blobs / working docs (large, not source)
+API Docs/
+PRD_*.md
+RESUME.md


### PR DESCRIPTION
Adds `API Docs/`, `PRD_*.md`, and `RESUME.md` to `.gitignore` so the large local API-reference blobs (11 MB webarchive, 538k-line swagger) and working docs don't get accidentally committed (`git add -A` had swept them in during the 2.0.0 work).

Tiny, no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)