### PR TITLE
Eclipse named methods for MCP delegation (orionapi 2.1.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -247,12 +247,15 @@ class BaseAPI:
 
         return data
 
-    def api_request(self, url, req_func=requests.get, timeout=30, **kwargs):
+    def api_request(self, url, req_func=None, timeout=30, **kwargs):
         """Make an authenticated API request with error handling.
 
         Args:
             url: The API endpoint URL
-            req_func: The requests function to use (get, post, put, delete)
+            req_func: The requests function to use (get, post, put, delete).
+                Defaults to ``requests.get``. Resolved at call time (not bound as a
+                default argument) so that patching ``requests.get`` in tests takes
+                effect for GET methods.
             timeout: Request timeout in seconds (default 30)
             **kwargs: Additional arguments passed to the request
 
@@ -264,6 +267,9 @@ class BaseAPI:
             NotFoundError: On 404 responses
             OrionAPIError: On other 4xx/5xx responses
         """
+        if req_func is None:
+            req_func = requests.get
+
         # Apply rate limiting
         self._rate_limiter.wait()
 

--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 import logging
 import re
@@ -2479,6 +2479,54 @@ class EclipseV1(EclipseBase):
         res = self.api_request(f"{self.base_url}/account/accounts/{internal_id}")
         return res.json()
 
+    def get_account_simple(self, account_id):
+        """Get a lightweight account record by internal ID.
+
+        Hits ``/account/accounts/simple/{id}`` — a lighter payload than the full
+        record returned by :meth:`get_account_details`.
+
+        Args:
+            account_id: Internal Eclipse account ID
+
+        Returns:
+            dict: Lightweight account record
+        """
+        res = self.api_request(f"{self.base_url}/account/accounts/simple/{account_id}")
+        return res.json()
+
+    def get_account_holdings_detail(self, account_id):
+        """Get holdings for an account via the account-path holdings endpoint.
+
+        Hits ``/account/accounts/{id}/holdings`` — a different path and shape than
+        :meth:`get_account_holdings` (which uses ``/holding/holdings/simple``).
+
+        Args:
+            account_id: Internal Eclipse account ID
+
+        Returns:
+            list: Holding dicts as returned by the account-path endpoint
+        """
+        res = self.api_request(f"{self.base_url}/account/accounts/{account_id}/holdings")
+        return res.json()
+
+    def get_out_of_tolerance_accounts(self, model_id, asset_id, asset_type="class"):
+        """Get accounts out of tolerance for a model asset.
+
+        Args:
+            model_id: Model ID (note: the API uses this value in the account path
+                segment — kept as-is per the documented endpoint quirk)
+            asset_id: Asset ID
+            asset_type: Asset type (default "class")
+
+        Returns:
+            list: Out-of-tolerance account dicts
+        """
+        res = self.api_request(
+            f"{self.base_url}/account/accounts/{model_id}/outOfTolerance/{asset_id}",
+            params={"assetType": asset_type},
+        )
+        return res.json()
+
     def get_all_account_details(self):
         """Get detailed information for all accounts.
 
@@ -2508,12 +2556,20 @@ class EclipseV1(EclipseBase):
         res = self.api_request(f"{self.base_url}/portfolio/portfolios/{portfolio_id}")
         return res.json()
 
-    def get_portfolio_accounts(self, portfolio_id):
+    def get_portfolio_accounts(self, portfolio_id, simple=False):
         """Get list of accounts for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+            simple: When True, hit the lightweight ``/accounts/simple`` path
+                (default False returns the full account records)
 
         Returns list of accounts with cash targets, sleeve settings, and values.
         """
-        res = self.api_request(f"{self.base_url}/portfolio/portfolios/{portfolio_id}/accounts")
+        path = f"/portfolio/portfolios/{portfolio_id}/accounts"
+        if simple:
+            path += "/simple"
+        res = self.api_request(f"{self.base_url}{path}")
         return res.json()
 
     def get_model_tolerance(self, portfolio_id, account_id, account_type="Normal"):
@@ -2532,18 +2588,21 @@ class EclipseV1(EclipseBase):
         )
         return res.json()
 
-    def get_all_portfolios(self, include_value=True, search=None):
+    def get_all_portfolios(self, include_value=True, search=None, top=None):
         """Get list of all portfolios.
 
         Args:
             include_value: Include holding values (default True)
             search: Optional search string
+            top: Optional max number of results (maps to ``$top``)
 
         Returns list of portfolios with basic info and optionally values.
         """
         params = {"includevalue": str(include_value).lower()}
         if search:
             params["search"] = search
+        if top is not None:
+            params["$top"] = top
         res = self.api_request(f"{self.base_url}/portfolio/portfolios/simple", params=params)
         return res.json()
 
@@ -2575,6 +2634,33 @@ class EclipseV1(EclipseBase):
         if search:
             params["search"] = search
         res = self.api_request(f"{self.base_url}/holding/holdings/simple", params=params)
+        return res.json()
+
+    def get_portfolio_holdings_detail(self, portfolio_id):
+        """Get holdings for a portfolio via the portfolio-path holdings endpoint.
+
+        Hits ``/portfolio/portfolios/{id}/holdings`` — a different path and shape
+        than :meth:`get_portfolio_holdings` (which uses ``/holding/holdings/simple``).
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            list: Holding dicts as returned by the portfolio-path endpoint
+        """
+        res = self.api_request(f"{self.base_url}/portfolio/portfolios/{portfolio_id}/holdings")
+        return res.json()
+
+    def get_taxlots(self, holding_id):
+        """Get tax lots for a holding.
+
+        Args:
+            holding_id: Holding ID
+
+        Returns:
+            list: Tax-lot dicts (acquisition date, cost basis, quantity, etc.)
+        """
+        res = self.api_request(f"{self.base_url}/holding/holdings/{holding_id}/taxlots")
         return res.json()
 
     def run_analytics(self):
@@ -2644,6 +2730,32 @@ class EclipseV1(EclipseBase):
         """
         return self.api_request(f"{self.base_url}/tradeorder/trades?isPending=true").json()
 
+    def get_trades(self, portfolio_id=None, top=None, is_pending=None):
+        """Get trade orders with optional portfolio / paging / pending filters.
+
+        Hits the same ``/tradeorder/trades`` endpoint as :meth:`get_orders` /
+        :meth:`get_orders_pending`, but lets the caller filter by portfolio and cap
+        the result count.
+
+        Args:
+            portfolio_id: Optional portfolio ID filter (maps to ``portfolioId``)
+            top: Optional max number of results (maps to ``$top``)
+            is_pending: Optional bool; when set, filter by pending status
+                (maps to ``isPending``)
+
+        Returns:
+            list: Trade order dicts
+        """
+        params = {}
+        if portfolio_id is not None:
+            params["portfolioId"] = portfolio_id
+        if top is not None:
+            params["$top"] = top
+        if is_pending is not None:
+            params["isPending"] = str(is_pending).lower()
+        res = self.api_request(f"{self.base_url}/tradeorder/trades", params=params)
+        return res.json()
+
     def cash_needs_trade(
         self,
         portfolio_ids,
@@ -2692,6 +2804,9 @@ class EclipseV1(EclipseBase):
         reason="",
         is_excel_import=False,
         sync=True,
+        selected_method_id=None,
+        spend_full_amount=None,
+        filter_type=None,
     ):
         """Generate Spend Cash trade for portfolios.
 
@@ -2702,6 +2817,12 @@ class EclipseV1(EclipseBase):
             reason: Reason for the trade
             is_excel_import: Whether this is from an Excel import (default False)
             sync: Wait for analytics to complete (default True)
+
+        Args (additional):
+            selected_method_id: Optional spend-cash calculation method id
+                (see ``get_spend_cash_methods``); added to the body only when provided
+            spend_full_amount: Optional bool; added to the body only when provided
+            filter_type: Optional filter type; added to the body only when provided
 
         Returns:
             dict with 'issues', 'success', and 'instanceId' fields
@@ -2716,9 +2837,157 @@ class EclipseV1(EclipseBase):
             "reason": reason,
             "isExcelImport": is_excel_import,
         }
+        if selected_method_id is not None:
+            payload["selectedMethodId"] = selected_method_id
+        if spend_full_amount is not None:
+            payload["spendFullAmount"] = spend_full_amount
+        if filter_type is not None:
+            payload["filterType"] = filter_type
 
         res = self.api_request(
             f"{self.base_url}/tradetool/spendcash/action/generatetrade", requests.post, json=payload
+        )
+        result = res.json()
+        self._maybe_wait_for_analytics(sync)
+        return result
+
+    def get_raise_cash_methods(self):
+        """Get the available raise-cash calculation methods.
+
+        Returns:
+            list: Calculation-method dicts (id, name, etc.)
+        """
+        res = self.api_request(f"{self.base_url}/tradetool/raisecash/calculation_methods")
+        return res.json()
+
+    def get_spend_cash_methods(self):
+        """Get the available spend-cash calculation methods.
+
+        Returns:
+            list: Calculation-method dicts (id, name, etc.)
+        """
+        res = self.api_request(f"{self.base_url}/tradetool/spendcash/calculation_methods")
+        return res.json()
+
+    @staticmethod
+    def _tlh_id_body(portfolio_ids, account_ids):
+        """Build a tax-loss-harvesting request body, omitting empty id lists."""
+        body = {}
+        if portfolio_ids is not None:
+            body["portfolioIds"] = portfolio_ids
+        if account_ids is not None:
+            body["accountIds"] = account_ids
+        return body
+
+    def get_tlh_securities(self, portfolio_ids=None, account_ids=None):
+        """Get tax-loss-harvesting candidate securities (preview only).
+
+        Args:
+            portfolio_ids: Optional list of portfolio IDs
+            account_ids: Optional list of account IDs
+
+        Returns:
+            list: Candidate security dicts
+        """
+        res = self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/securities",
+            requests.post,
+            json=self._tlh_id_body(portfolio_ids, account_ids),
+        )
+        return res.json()
+
+    def check_tlh_gain_loss(self, portfolio_ids=None, account_ids=None):
+        """Check projected gain/loss for tax-loss harvesting (preview only).
+
+        Args:
+            portfolio_ids: Optional list of portfolio IDs
+            account_ids: Optional list of account IDs
+
+        Returns:
+            dict: Projected gain/loss summary
+        """
+        res = self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/checkGainLoss",
+            requests.post,
+            json=self._tlh_id_body(portfolio_ids, account_ids),
+        )
+        return res.json()
+
+    def tlh_trade(self, portfolio_ids=None, account_ids=None, is_view_only=True, sync=False):
+        """Generate a tax-loss-harvesting trade (preview/staging by default).
+
+        Args:
+            portfolio_ids: Optional list of portfolio IDs
+            account_ids: Optional list of account IDs
+            is_view_only: If True (default), preview trades without executing
+            sync: Wait for analytics to complete (default False)
+
+        Returns:
+            dict: Generated trade preview (instanceId, trades, etc.)
+        """
+        payload = self._tlh_id_body(portfolio_ids, account_ids)
+        payload["isViewOnly"] = is_view_only
+        res = self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/generateTrade",
+            requests.post,
+            json=payload,
+        )
+        result = res.json()
+        self._maybe_wait_for_analytics(sync)
+        return result
+
+    def rebalance_trade(
+        self,
+        portfolio_ids=None,
+        account_ids=None,
+        filter_type=None,
+        is_view_only=True,
+        max_gain_amount=0,
+        minimum_trade_amount=0,
+        minimum_trade_amount_type="$",
+        allow_wash_sale=False,
+        rounding=0,
+        sync=False,
+    ):
+        """Generate a rebalance trade (preview/staging by default).
+
+        Args:
+            portfolio_ids: Optional list of portfolio IDs
+            account_ids: Optional list of account IDs
+            filter_type: Optional filter type (maps to ``filterType``)
+            is_view_only: If True (default), preview trades without executing
+            max_gain_amount: Max gain amount (default 0)
+            minimum_trade_amount: Minimum trade amount (default 0)
+            minimum_trade_amount_type: Minimum trade amount type, "$" or "%" (default "$")
+            allow_wash_sale: Whether to allow wash sales (default False)
+            rounding: Rounding setting (default 0)
+            sync: Wait for analytics to complete (default False)
+
+        Returns:
+            dict: Generated trade preview (instanceId, trades, etc.)
+        """
+        payload = {
+            "filterType": filter_type,
+            "isViewOnly": is_view_only,
+            "isExcelImport": False,
+            "maxGainAmount": max_gain_amount,
+            "minimumTradeAmount": {
+                "amount": minimum_trade_amount,
+                "type": minimum_trade_amount_type,
+            },
+            "allowWashSale": allow_wash_sale,
+            "allowShortTermGain": None,
+            "priorityRanking": [],
+            "rounding": rounding,
+        }
+        if portfolio_ids is not None:
+            payload["portfolioIds"] = portfolio_ids
+        if account_ids is not None:
+            payload["accountIds"] = account_ids
+        res = self.api_request(
+            f"{self.base_url}/tradetool/rebalancer/action/generatetrade",
+            requests.post,
+            json=payload,
         )
         result = res.json()
         self._maybe_wait_for_analytics(sync)
@@ -2732,20 +3001,26 @@ class EclipseV1(EclipseBase):
         """
         return self.api_request(f"{self.base_url}/tradeorder/closedtrades").json()
 
-    def get_trade_instances(self, start_date, end_date):
+    def get_trade_instances(self, start_date, end_date, normalize=True):
         """Get trade instances (batches of trades) within a date range.
 
         Args:
             start_date: Start date (YYYY-MM-DD format)
             end_date: End date (YYYY-MM-DD format)
+            normalize: When True (default), map the numeric tradeInstanceType /
+                tradeInstanceSubType IDs to friendly names. When False, return the
+                raw response unchanged (matching the API output).
 
         Returns:
             list: List of trade instance dicts with id, orderCount, executeStatus,
-                  tradeInstanceType (string), tradeInstanceSubType (string), etc.
+                  tradeInstanceType, tradeInstanceSubType, etc.
         """
         instances = self.api_request(
             f"{self.base_url}/tradeorder/instances?startDate={start_date}&endDate={end_date}"
         ).json()
+
+        if not normalize:
+            return instances
 
         # Convert type/subtype IDs to friendly names
         for inst in instances:
@@ -2760,13 +3035,22 @@ class EclipseV1(EclipseBase):
 
     # Model Maintenance
 
-    def get_all_models(self):
+    def get_all_models(self, name=None, top=None):
         """Get all investment models.
+
+        Args:
+            name: Optional name filter
+            top: Optional max number of results (maps to ``$top``)
 
         Returns:
             list: List of model dicts with id, name, status, etc.
         """
-        res = self.api_request(f"{self.base_url}/modeling/models")
+        params = {}
+        if name is not None:
+            params["name"] = name
+        if top is not None:
+            params["$top"] = top
+        res = self.api_request(f"{self.base_url}/modeling/models", params=params)
         return res.json()
 
     def get_model(self, id):
@@ -2781,18 +3065,114 @@ class EclipseV1(EclipseBase):
         res = self.api_request(f"{self.base_url}/modeling/models/{id}")
         return res.json()
 
-    def get_model_allocations(self, id):
-        """Get aggregated allocations for a model.
+    def get_model_allocations(self, id, aggregate=True):
+        """Get allocations for a model.
 
         Args:
             id: Model ID
+            aggregate: When True (default), aggregate allocations across the model
+                tree (``aggregateAllocations=true``); when False, return per-node
+                allocations.
 
         Returns:
             list: List of allocation dicts with target percentages
         """
         res = self.api_request(
-            f"{self.base_url}/modeling/models/{id}/allocations?aggregateAllocations=true"
+            f"{self.base_url}/modeling/models/{id}/allocations",
+            params={"aggregateAllocations": str(aggregate).lower()},
         )
+        return res.json()
+
+    def get_model_nodes(self, model_id):
+        """Get the node tree for a model.
+
+        Args:
+            model_id: Model ID
+
+        Returns:
+            dict: Node tree with ``levels``, ``modelId`` and ``preSelectedNodeId``
+        """
+        res = self.api_request(f"{self.base_url}/modeling/models/{model_id}/Model/nodes")
+        return res.json()
+
+    def get_model_portfolios(self, model_id):
+        """Get portfolios assigned to a model.
+
+        Args:
+            model_id: Model ID
+
+        Returns:
+            list: Portfolio dicts assigned to the model
+        """
+        res = self.api_request(f"{self.base_url}/modeling/models/{model_id}/portfolios")
+        return res.json()
+
+    def get_model_pending(self, model_id):
+        """Get pending changes for a model.
+
+        Args:
+            model_id: Model ID
+
+        Returns:
+            dict: Pending-change details
+        """
+        res = self.api_request(f"{self.base_url}/modeling/models/{model_id}/pending")
+        return res.json()
+
+    def get_model_analysis(self, model_id, asset_type="securityset"):
+        """Get model analysis for a model.
+
+        Args:
+            model_id: Model ID
+            asset_type: Asset type to analyze (default "securityset")
+
+        Returns:
+            dict: Model analysis results
+        """
+        res = self.api_request(
+            f"{self.base_url}/modeling/models/{model_id}/modelAnalysis",
+            params={
+                "assetType": asset_type,
+                "isIncludeTradeBlockAccount": 0,
+                "isExcludeAsset": 0,
+            },
+        )
+        return res.json()
+
+    def get_model_status(self):
+        """Get the list of model statuses.
+
+        Returns:
+            list: Model-status dicts
+        """
+        res = self.api_request(f"{self.base_url}/modeling/models/modelStatus")
+        return res.json()
+
+    def get_model_types(self):
+        """Get the list of model types.
+
+        Returns:
+            list: Model-type dicts
+        """
+        res = self.api_request(f"{self.base_url}/modeling/models/modelTypes")
+        return res.json()
+
+    def get_submodels(self, model_type=None, search=None):
+        """Get submodels, optionally filtered by type and name.
+
+        Args:
+            model_type: Optional model-type filter (maps to ``modelType``)
+            search: Optional name filter (maps to ``name``)
+
+        Returns:
+            list: Submodel dicts
+        """
+        params = {}
+        if model_type is not None:
+            params["modelType"] = model_type
+        if search is not None:
+            params["name"] = search
+        res = self.api_request(f"{self.base_url}/modeling/models/submodels", params=params)
         return res.json()
 
     def get_all_security_sets(self):
@@ -2814,6 +3194,41 @@ class EclipseV1(EclipseBase):
             dict: Security set details including securities and allocations
         """
         res = self.api_request(f"{self.base_url}/security/securityset/details/{id}")
+        return res.json()
+
+    def get_security_set_summary(self, id):
+        """Get a security set by ID via the summary endpoint.
+
+        Hits ``/security/securityset/{id}`` — a different path than
+        :meth:`get_security_set` (which uses ``/security/securityset/details/{id}``).
+
+        Args:
+            id: Security set ID
+
+        Returns:
+            dict: Security set summary
+        """
+        res = self.api_request(f"{self.base_url}/security/securityset/{id}")
+        return res.json()
+
+    def get_security_set_details(self):
+        """Get the full security-set detail list.
+
+        Hits ``/security/securityset/detail`` (documented as a large list across all
+        sets).
+
+        .. note::
+            As of 2026-05 this endpoint returns ``400 'id is not numeric string'`` on
+            live Eclipse — the server routes the ``detail`` segment into the
+            ``/security/securityset/{id}`` param route instead. Kept faithful to the
+            documented endpoint (and the Eclipse MCP, which calls the same path), but
+            the upstream route appears broken. Use :meth:`get_all_security_sets` plus
+            :meth:`get_security_set` per id as a working alternative.
+
+        Returns:
+            list: Security-set detail dicts
+        """
+        res = self.api_request(f"{self.base_url}/security/securityset/detail")
         return res.json()
 
     def add_model(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.0.0"
+version = "2.1.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -450,7 +450,7 @@ class TestEclipseRequest:
         """version='v1' targets the /v1 base with a GET by default."""
         api = _eclipse_for_set_asides()
         mock_get = Mock(return_value=Mock(ok=True, json=lambda: {"ok": True}))
-        with patch("requests.get", mock_get):
+        with patch.object(api, "api_request", mock_get):
             result = api.eclipse_request("account/accounts/simple")
         assert result == {"ok": True}
         assert mock_get.call_args.args[0] == (
@@ -475,7 +475,7 @@ class TestEclipseRequest:
         """Paths with or without a leading slash resolve identically."""
         api = _eclipse_for_set_asides()
         mock_get = Mock(return_value=Mock(ok=True, json=lambda: {}))
-        with patch("requests.get", mock_get):
+        with patch.object(api, "api_request", mock_get):
             api.eclipse_request("Account/Accounts", version="v2")
             api.eclipse_request("/Account/Accounts", version="v2")
         urls = {call.args[0] for call in mock_get.call_args_list}
@@ -521,3 +521,352 @@ class TestEclipseUnifierAndAlias:
         assert isinstance(api, EclipseAPI)
         assert api.eclipse_token == "tok"
         assert api.v1.eclipse_token == "tok"
+
+
+def _eclipse_v1():
+    """Construct an EclipseV1 with auth/login patched out for unit tests."""
+    with patch.object(EclipseV1, "login"):
+        api = EclipseV1(usr="test", pwd="pass")
+    api.eclipse_token = "test-token"
+    return api
+
+
+def _mock_get(records):
+    """Return an api_request mock whose response .json() yields the given records.
+
+    Patched onto the instance ``api_request`` (not ``requests.get``) because
+    ``api_request``'s ``req_func=requests.get`` default is bound at definition time,
+    so patching ``requests.get`` would not take effect for GET methods.
+    """
+    mock_response = Mock()
+    mock_response.ok = True
+    mock_response.json.return_value = records
+    return Mock(return_value=mock_response)
+
+
+V1_BASE = "https://api.orioneclipse.com/v1"
+
+
+class TestEclipseV1NewGetEndpoints:
+    """URL/params coverage for the new EclipseV1 GET methods (PRD 2.1.0)."""
+
+    def test_get_taxlots(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([{"lot": 1}])
+        with patch.object(api, "api_request", mock_get):
+            result = api.get_taxlots(987)
+        assert result == [{"lot": 1}]
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/holding/holdings/987/taxlots"
+
+    def test_get_raise_cash_methods(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([{"id": 1}])
+        with patch.object(api, "api_request", mock_get):
+            api.get_raise_cash_methods()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/tradetool/raisecash/calculation_methods"
+
+    def test_get_spend_cash_methods(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([{"id": 1}])
+        with patch.object(api, "api_request", mock_get):
+            api.get_spend_cash_methods()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/tradetool/spendcash/calculation_methods"
+
+    def test_get_model_nodes(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_nodes(55)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/Model/nodes"
+
+    def test_get_model_portfolios(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_portfolios(55)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/portfolios"
+
+    def test_get_model_pending(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get({})
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_pending(55)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/pending"
+
+    def test_get_model_analysis(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get({})
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_analysis(55, asset_type="class")
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/modelAnalysis"
+        assert mock_get.call_args.kwargs["params"] == {
+            "assetType": "class",
+            "isIncludeTradeBlockAccount": 0,
+            "isExcludeAsset": 0,
+        }
+
+    def test_get_model_analysis_default_asset_type(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get({})
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_analysis(55)
+        assert mock_get.call_args.kwargs["params"]["assetType"] == "securityset"
+
+    def test_get_model_status(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_status()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/modelStatus"
+
+    def test_get_model_types(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_types()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/modelTypes"
+
+    def test_get_submodels_no_filters(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_submodels()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/submodels"
+        assert mock_get.call_args.kwargs["params"] == {}
+
+    def test_get_submodels_with_filters(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_submodels(model_type="A", search="growth")
+        assert mock_get.call_args.kwargs["params"] == {"modelType": "A", "name": "growth"}
+
+    def test_get_out_of_tolerance_accounts(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_out_of_tolerance_accounts(10, 20, asset_type="category")
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/account/accounts/10/outOfTolerance/20"
+        assert mock_get.call_args.kwargs["params"] == {"assetType": "category"}
+
+    def test_get_security_set_details(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_security_set_details()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/security/securityset/detail"
+
+    def test_get_security_set_summary(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get({})
+        with patch.object(api, "api_request", mock_get):
+            api.get_security_set_summary(42)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/security/securityset/42"
+
+    def test_get_account_simple(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get({})
+        with patch.object(api, "api_request", mock_get):
+            api.get_account_simple(123)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/account/accounts/simple/123"
+
+    def test_get_account_holdings_detail(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_account_holdings_detail(123)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/account/accounts/123/holdings"
+
+    def test_get_portfolio_holdings_detail(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_portfolio_holdings_detail(77)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/77/holdings"
+
+    def test_get_trades_no_filters(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_trades()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/tradeorder/trades"
+        assert mock_get.call_args.kwargs["params"] == {}
+
+    def test_get_trades_with_filters(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_trades(portfolio_id=5, top=10, is_pending=True)
+        assert mock_get.call_args.kwargs["params"] == {
+            "portfolioId": 5,
+            "$top": 10,
+            "isPending": "true",
+        }
+
+
+class TestEclipseV1ParamAdditions:
+    """Coverage for params added in-place to existing EclipseV1 methods."""
+
+    def test_get_portfolio_accounts_full(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_portfolio_accounts(9)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/9/accounts"
+
+    def test_get_portfolio_accounts_simple(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_portfolio_accounts(9, simple=True)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/9/accounts/simple"
+
+    def test_get_all_models_no_params(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_all_models()
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models"
+        assert mock_get.call_args.kwargs["params"] == {}
+
+    def test_get_all_models_with_params(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_all_models(name="Core", top=5)
+        assert mock_get.call_args.kwargs["params"] == {"name": "Core", "$top": 5}
+
+    def test_get_all_portfolios_default_unchanged(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_all_portfolios()
+        # default behavior unchanged: includevalue=true, no $top
+        assert mock_get.call_args.kwargs["params"] == {"includevalue": "true"}
+
+    def test_get_all_portfolios_with_top(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_all_portfolios(include_value=False, top=25)
+        assert mock_get.call_args.kwargs["params"] == {"includevalue": "false", "$top": 25}
+
+    def test_get_model_allocations_default_aggregate(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_allocations(3)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/3/allocations"
+        assert mock_get.call_args.kwargs["params"] == {"aggregateAllocations": "true"}
+
+    def test_get_model_allocations_no_aggregate(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch.object(api, "api_request", mock_get):
+            api.get_model_allocations(3, aggregate=False)
+        assert mock_get.call_args.kwargs["params"] == {"aggregateAllocations": "false"}
+
+    def test_get_trade_instances_normalize_false_returns_raw(self):
+        api = _eclipse_v1()
+        raw = [{"tradeInstanceType": 1, "tradeInstanceSubType": 2}]
+        mock_get = _mock_get(raw)
+        with patch.object(api, "api_request", mock_get):
+            result = api.get_trade_instances("2026-01-01", "2026-01-31", normalize=False)
+        # Raw IDs preserved, not mapped to friendly names
+        assert result == raw
+        assert result[0]["tradeInstanceType"] == 1
+
+    def test_get_trade_instances_normalize_true_maps_names(self):
+        api = _eclipse_v1()
+        raw = [{"tradeInstanceType": 1, "tradeInstanceSubType": 2}]
+        mock_get = _mock_get(raw)
+        with patch.object(api, "api_request", mock_get):
+            result = api.get_trade_instances("2026-01-01", "2026-01-31")
+        # Default normalize=True maps IDs to strings (or None if unmapped)
+        assert result[0]["tradeInstanceType"] != 1
+
+
+class TestEclipseV1TradeGenPreview:
+    """Trade-gen POSTs default to preview (isViewOnly=True, sync=False)."""
+
+    def test_get_tlh_securities_omits_none_ids(self):
+        api = _eclipse_v1()
+        mock_post = _mock_post([])
+        with patch("requests.post", mock_post):
+            api.get_tlh_securities(portfolio_ids=[1, 2])
+        assert mock_post.call_args.args[0] == (f"{V1_BASE}/tradetool/taxLossHarvesting/securities")
+        assert mock_post.call_args.kwargs["json"] == {"portfolioIds": [1, 2]}
+
+    def test_check_tlh_gain_loss(self):
+        api = _eclipse_v1()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.check_tlh_gain_loss(account_ids=[7])
+        assert mock_post.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/checkGainLoss"
+        )
+        assert mock_post.call_args.kwargs["json"] == {"accountIds": [7]}
+
+    def test_tlh_trade_preview_defaults(self):
+        api = _eclipse_v1()
+        mock_post = _mock_post({"instanceId": 1})
+        with (
+            patch("requests.post", mock_post),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics") as mock_wait,
+        ):
+            api.tlh_trade(portfolio_ids=[1])
+        assert mock_post.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/generateTrade"
+        )
+        body = mock_post.call_args.kwargs["json"]
+        assert body["isViewOnly"] is True
+        assert body["portfolioIds"] == [1]
+        # sync defaults False -> wait called with False (no-op)
+        mock_wait.assert_called_once_with(False)
+
+    def test_rebalance_trade_preview_defaults(self):
+        api = _eclipse_v1()
+        mock_post = _mock_post({"instanceId": 1})
+        with (
+            patch("requests.post", mock_post),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics") as mock_wait,
+        ):
+            api.rebalance_trade(portfolio_ids=[1, 2])
+        assert mock_post.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/rebalancer/action/generatetrade"
+        )
+        body = mock_post.call_args.kwargs["json"]
+        assert body["isViewOnly"] is True
+        assert body["isExcelImport"] is False
+        assert body["minimumTradeAmount"] == {"amount": 0, "type": "$"}
+        assert body["allowShortTermGain"] is None
+        assert body["priorityRanking"] == []
+        assert body["portfolioIds"] == [1, 2]
+        assert "accountIds" not in body
+        mock_wait.assert_called_once_with(False)
+
+    def test_spend_cash_trade_extra_params_only_when_set(self):
+        api = _eclipse_v1()
+        mock_post = _mock_post({"instanceId": 1})
+        with (
+            patch("requests.post", mock_post),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
+        ):
+            api.spend_cash_trade([1])
+        body = mock_post.call_args.kwargs["json"]
+        assert "selectedMethodId" not in body
+        assert "spendFullAmount" not in body
+        assert "filterType" not in body
+
+    def test_spend_cash_trade_extra_params_present(self):
+        api = _eclipse_v1()
+        mock_post = _mock_post({"instanceId": 1})
+        with (
+            patch("requests.post", mock_post),
+            patch.object(EclipseV1, "_maybe_wait_for_analytics"),
+        ):
+            api.spend_cash_trade([1], selected_method_id=3, spend_full_amount=True, filter_type="X")
+        body = mock_post.call_args.kwargs["json"]
+        assert body["selectedMethodId"] == 3
+        assert body["spendFullAmount"] is True
+        assert body["filterType"] == "X"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -450,7 +450,7 @@ class TestEclipseRequest:
         """version='v1' targets the /v1 base with a GET by default."""
         api = _eclipse_for_set_asides()
         mock_get = Mock(return_value=Mock(ok=True, json=lambda: {"ok": True}))
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             result = api.eclipse_request("account/accounts/simple")
         assert result == {"ok": True}
         assert mock_get.call_args.args[0] == (
@@ -475,7 +475,7 @@ class TestEclipseRequest:
         """Paths with or without a leading slash resolve identically."""
         api = _eclipse_for_set_asides()
         mock_get = Mock(return_value=Mock(ok=True, json=lambda: {}))
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.eclipse_request("Account/Accounts", version="v2")
             api.eclipse_request("/Account/Accounts", version="v2")
         urls = {call.args[0] for call in mock_get.call_args_list}
@@ -532,11 +532,10 @@ def _eclipse_v1():
 
 
 def _mock_get(records):
-    """Return an api_request mock whose response .json() yields the given records.
+    """Return a requests.get mock yielding the given JSON records.
 
-    Patched onto the instance ``api_request`` (not ``requests.get``) because
-    ``api_request``'s ``req_func=requests.get`` default is bound at definition time,
-    so patching ``requests.get`` would not take effect for GET methods.
+    Patching ``requests.get`` works for GET methods because ``api_request`` resolves
+    ``req_func`` at call time (it is not bound as a default argument).
     """
     mock_response = Mock()
     mock_response.ok = True
@@ -553,7 +552,7 @@ class TestEclipseV1NewGetEndpoints:
     def test_get_taxlots(self):
         api = _eclipse_v1()
         mock_get = _mock_get([{"lot": 1}])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             result = api.get_taxlots(987)
         assert result == [{"lot": 1}]
         assert mock_get.call_args.args[0] == f"{V1_BASE}/holding/holdings/987/taxlots"
@@ -561,42 +560,42 @@ class TestEclipseV1NewGetEndpoints:
     def test_get_raise_cash_methods(self):
         api = _eclipse_v1()
         mock_get = _mock_get([{"id": 1}])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_raise_cash_methods()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/tradetool/raisecash/calculation_methods"
 
     def test_get_spend_cash_methods(self):
         api = _eclipse_v1()
         mock_get = _mock_get([{"id": 1}])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_spend_cash_methods()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/tradetool/spendcash/calculation_methods"
 
     def test_get_model_nodes(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_nodes(55)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/Model/nodes"
 
     def test_get_model_portfolios(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_portfolios(55)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/portfolios"
 
     def test_get_model_pending(self):
         api = _eclipse_v1()
         mock_get = _mock_get({})
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_pending(55)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/pending"
 
     def test_get_model_analysis(self):
         api = _eclipse_v1()
         mock_get = _mock_get({})
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_analysis(55, asset_type="class")
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/55/modelAnalysis"
         assert mock_get.call_args.kwargs["params"] == {
@@ -608,28 +607,28 @@ class TestEclipseV1NewGetEndpoints:
     def test_get_model_analysis_default_asset_type(self):
         api = _eclipse_v1()
         mock_get = _mock_get({})
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_analysis(55)
         assert mock_get.call_args.kwargs["params"]["assetType"] == "securityset"
 
     def test_get_model_status(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_status()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/modelStatus"
 
     def test_get_model_types(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_types()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/modelTypes"
 
     def test_get_submodels_no_filters(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_submodels()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/submodels"
         assert mock_get.call_args.kwargs["params"] == {}
@@ -637,14 +636,14 @@ class TestEclipseV1NewGetEndpoints:
     def test_get_submodels_with_filters(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_submodels(model_type="A", search="growth")
         assert mock_get.call_args.kwargs["params"] == {"modelType": "A", "name": "growth"}
 
     def test_get_out_of_tolerance_accounts(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_out_of_tolerance_accounts(10, 20, asset_type="category")
         assert mock_get.call_args.args[0] == f"{V1_BASE}/account/accounts/10/outOfTolerance/20"
         assert mock_get.call_args.kwargs["params"] == {"assetType": "category"}
@@ -652,42 +651,42 @@ class TestEclipseV1NewGetEndpoints:
     def test_get_security_set_details(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_security_set_details()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/security/securityset/detail"
 
     def test_get_security_set_summary(self):
         api = _eclipse_v1()
         mock_get = _mock_get({})
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_security_set_summary(42)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/security/securityset/42"
 
     def test_get_account_simple(self):
         api = _eclipse_v1()
         mock_get = _mock_get({})
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_account_simple(123)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/account/accounts/simple/123"
 
     def test_get_account_holdings_detail(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_account_holdings_detail(123)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/account/accounts/123/holdings"
 
     def test_get_portfolio_holdings_detail(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_portfolio_holdings_detail(77)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/77/holdings"
 
     def test_get_trades_no_filters(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_trades()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/tradeorder/trades"
         assert mock_get.call_args.kwargs["params"] == {}
@@ -695,7 +694,7 @@ class TestEclipseV1NewGetEndpoints:
     def test_get_trades_with_filters(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_trades(portfolio_id=5, top=10, is_pending=True)
         assert mock_get.call_args.kwargs["params"] == {
             "portfolioId": 5,
@@ -710,21 +709,21 @@ class TestEclipseV1ParamAdditions:
     def test_get_portfolio_accounts_full(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_portfolio_accounts(9)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/9/accounts"
 
     def test_get_portfolio_accounts_simple(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_portfolio_accounts(9, simple=True)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/9/accounts/simple"
 
     def test_get_all_models_no_params(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_all_models()
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models"
         assert mock_get.call_args.kwargs["params"] == {}
@@ -732,14 +731,14 @@ class TestEclipseV1ParamAdditions:
     def test_get_all_models_with_params(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_all_models(name="Core", top=5)
         assert mock_get.call_args.kwargs["params"] == {"name": "Core", "$top": 5}
 
     def test_get_all_portfolios_default_unchanged(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_all_portfolios()
         # default behavior unchanged: includevalue=true, no $top
         assert mock_get.call_args.kwargs["params"] == {"includevalue": "true"}
@@ -747,14 +746,14 @@ class TestEclipseV1ParamAdditions:
     def test_get_all_portfolios_with_top(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_all_portfolios(include_value=False, top=25)
         assert mock_get.call_args.kwargs["params"] == {"includevalue": "false", "$top": 25}
 
     def test_get_model_allocations_default_aggregate(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_allocations(3)
         assert mock_get.call_args.args[0] == f"{V1_BASE}/modeling/models/3/allocations"
         assert mock_get.call_args.kwargs["params"] == {"aggregateAllocations": "true"}
@@ -762,7 +761,7 @@ class TestEclipseV1ParamAdditions:
     def test_get_model_allocations_no_aggregate(self):
         api = _eclipse_v1()
         mock_get = _mock_get([])
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             api.get_model_allocations(3, aggregate=False)
         assert mock_get.call_args.kwargs["params"] == {"aggregateAllocations": "false"}
 
@@ -770,7 +769,7 @@ class TestEclipseV1ParamAdditions:
         api = _eclipse_v1()
         raw = [{"tradeInstanceType": 1, "tradeInstanceSubType": 2}]
         mock_get = _mock_get(raw)
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             result = api.get_trade_instances("2026-01-01", "2026-01-31", normalize=False)
         # Raw IDs preserved, not mapped to friendly names
         assert result == raw
@@ -780,7 +779,7 @@ class TestEclipseV1ParamAdditions:
         api = _eclipse_v1()
         raw = [{"tradeInstanceType": 1, "tradeInstanceSubType": 2}]
         mock_get = _mock_get(raw)
-        with patch.object(api, "api_request", mock_get):
+        with patch("requests.get", mock_get):
             result = api.get_trade_instances("2026-01-01", "2026-01-31")
         # Default normalize=True maps IDs to strings (or None if unmapped)
         assert result[0]["tradeInstanceType"] != 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -888,3 +888,133 @@ class TestOrionAPI:
             accounts[0]["id"], start_date, end_date, entity_type="account"
         )
         assert isinstance(performance, dict)
+
+
+class TestEclipse21Endpoints:
+    """Live smoke tests for the read/preview methods added in orionapi 2.1.0.
+
+    These fetch real data to confirm the documented endpoints still respond with
+    the expected shape — catching upstream route breakage that mocked unit tests
+    cannot. Skipped without ECLIPSE_USER/ECLIPSE_PWD.
+    """
+
+    def _first_model_id(self, client):
+        models = client.get_all_models(top=5)
+        if not models:
+            pytest.skip("No models available")
+        return models[0]["id"]
+
+    def _first_portfolio_id(self, client):
+        portfolios = client.get_all_portfolios(top=5)
+        if not portfolios:
+            pytest.skip("No portfolios available")
+        return portfolios[0]["id"]
+
+    # --- no-arg trade-tool / model reference endpoints ---
+
+    def test_get_raise_cash_methods(self, eclipse_client):
+        assert isinstance(eclipse_client.get_raise_cash_methods(), list)
+
+    def test_get_spend_cash_methods(self, eclipse_client):
+        assert isinstance(eclipse_client.get_spend_cash_methods(), list)
+
+    def test_get_model_status(self, eclipse_client):
+        assert isinstance(eclipse_client.get_model_status(), list)
+
+    def test_get_model_types(self, eclipse_client):
+        assert isinstance(eclipse_client.get_model_types(), list)
+
+    def test_get_submodels(self, eclipse_client):
+        assert isinstance(eclipse_client.get_submodels(), list)
+
+    # --- paged / filtered variants of existing list endpoints ---
+
+    def test_get_all_models_top(self, eclipse_client):
+        assert isinstance(eclipse_client.get_all_models(top=3), list)
+
+    def test_get_all_portfolios_top(self, eclipse_client):
+        assert isinstance(eclipse_client.get_all_portfolios(top=3), list)
+
+    def test_get_trades_top(self, eclipse_client):
+        assert isinstance(eclipse_client.get_trades(top=3), list)
+
+    def test_get_trade_instances_raw(self, eclipse_client):
+        from datetime import datetime, timedelta
+
+        end_date = datetime.now().strftime("%Y-%m-%d")
+        start_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+        assert isinstance(
+            eclipse_client.get_trade_instances(start_date, end_date, normalize=False), list
+        )
+
+    # --- model-scoped endpoints ---
+
+    def test_get_model_nodes(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.get_model_nodes(self._first_model_id(eclipse_client)), dict
+        )
+
+    def test_get_model_portfolios(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.get_model_portfolios(self._first_model_id(eclipse_client)), list
+        )
+
+    def test_get_model_pending(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.get_model_pending(self._first_model_id(eclipse_client)), dict
+        )
+
+    def test_get_model_analysis(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.get_model_analysis(self._first_model_id(eclipse_client)), dict
+        )
+
+    def test_get_model_allocations_no_aggregate(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.get_model_allocations(
+                self._first_model_id(eclipse_client), aggregate=False
+            ),
+            list,
+        )
+
+    # --- account / portfolio path variants ---
+
+    def test_get_portfolio_accounts_simple(self, eclipse_client):
+        pid = self._first_portfolio_id(eclipse_client)
+        assert isinstance(eclipse_client.get_portfolio_accounts(pid, simple=True), list)
+
+    def test_get_portfolio_holdings_detail(self, eclipse_client):
+        pid = self._first_portfolio_id(eclipse_client)
+        assert isinstance(eclipse_client.get_portfolio_holdings_detail(pid), list)
+
+    def test_account_simple_holdings_and_taxlots(self, eclipse_client):
+        pid = self._first_portfolio_id(eclipse_client)
+        accts = eclipse_client.get_portfolio_accounts(pid, simple=True)
+        if not accts:
+            pytest.skip("No accounts in portfolio")
+        account_id = accts[0]["accountId"]
+
+        assert isinstance(eclipse_client.get_account_simple(account_id), dict)
+
+        holdings = eclipse_client.get_account_holdings_detail(account_id)
+        assert isinstance(holdings, list)
+        if not holdings:
+            pytest.skip("No holdings to source a tax-lot from")
+        assert isinstance(eclipse_client.get_taxlots(holdings[0]["id"]), list)
+
+    # --- security sets ---
+
+    def test_get_security_set_summary(self, eclipse_client):
+        sets = eclipse_client.get_all_security_sets()
+        if not sets:
+            pytest.skip("No security sets available")
+        assert isinstance(eclipse_client.get_security_set_summary(sets[0]["id"]), dict)
+
+    @pytest.mark.xfail(
+        reason="Upstream Eclipse routes /security/securityset/detail into the /{id} "
+        "param route, returning 400 'id is not numeric string'. Use get_all_security_sets "
+        "+ get_security_set(id). Flips to XPASS if Eclipse fixes the route.",
+        strict=False,
+    )
+    def test_get_security_set_details(self, eclipse_client):
+        assert isinstance(eclipse_client.get_security_set_details(), list)


### PR DESCRIPTION
## Context
The DeeSam Eclipse MCP server delegates all Eclipse auth + HTTP to `orionapi`, but several tools still reach endpoints through the generic `api_request(<url>)` passthrough because no faithful named method exists. This PR adds those named methods to `EclipseV1` so each MCP tool can flip to a named method **without changing its output** (PRD `prd-orionapi-eclipse-endpoints.md`). Scope is **read + preview only** — no execute/approve/delete. New `EclipseV1` methods are automatically reachable on the `Eclipse` unifier via `__getattr__`.

## New methods (Bucket A)
`get_taxlots`, `get_raise_cash_methods`, `get_spend_cash_methods`, `get_model_nodes`, `get_model_portfolios`, `get_model_pending`, `get_model_analysis`, `get_model_status`, `get_model_types`, `get_submodels`, `get_out_of_tolerance_accounts`, `get_security_set_details`, and preview-only trade-gen POSTs `get_tlh_securities`, `check_tlh_gain_loss`, `tlh_trade`, `rebalance_trade` (default `is_view_only=True`, `sync=False`).

## New different-path methods (Bucket B)
`get_account_simple`, `get_account_holdings_detail`, `get_portfolio_holdings_detail`, `get_security_set_summary`, `get_trades`.

## Params added in place (existing defaults unchanged)
`get_portfolio_accounts(simple=)`, `get_all_models(name=, top=)`, `get_all_portfolios(top=)`, `get_trade_instances(normalize=)`, `get_model_allocations(aggregate=)`, `spend_cash_trade(selected_method_id=, spend_full_amount=, filter_type=)`.

## Verification
- Every new GET endpoint **live-verified** against Eclipse and returns the expected shape — **except** `get_security_set_details`, which returns `400 'id is not numeric string'` upstream (the server routes the `detail` segment into the `/security/securityset/{id}` param route). Kept faithful to the documented endpoint / MCP call but documented as broken upstream; the MCP's own `get_security_set_details` tool hits the identical URL and is affected too. Working alternative: `get_all_security_sets` + `get_security_set(id)`.
- Preview-only trade-gen POSTs were **not** invoked live; unit tests assert `isViewOnly=True` in the body and `sync` defaults to `False`.
- `ruff check` / `ruff format --check` clean; full `pytest` green (**316 passed, 10 skipped**, incl. live integration suite), with new mocked unit tests for every added/changed method.
- Version bumped 2.0.0 → 2.1.0 in `orionapi/__init__.py` and `pyproject.toml`. **No release** — review, then `gh release create v2.1.0`.

## Report to PRD author (no code)
- `search_securities(search, top=20, exclude_cash=True)` already supports `top` and an optional exclude-cash flag — the PRD's "add `$top` / make exclude-cash optional" is already satisfied. Point the MCP at `search_securities` (param is `top`).
- `get_security_set_details` / `/security/securityset/detail` 400s on live (see above) — the existing MCP tool is affected.

## Follow-up (out of scope)
DeeSam PR swapping each MCP tool from the raw `api_request` passthrough to its named method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)