### PR TITLE
Eclipse v2 coverage batch 2: Trading instances / Optimization / SavedView / Notes (2.3.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 import logging
 import re
@@ -290,10 +290,16 @@ class BaseAPI:
         res = req_func(url, headers=headers, **kwargs)
 
         if not res.ok:
-            # Try to get error message from response body
+            # Try to get error message from response body. The body may be a JSON
+            # object ({"message": ...}), a bare JSON string, a list, or non-JSON —
+            # so guard the .get() to avoid masking the real HTTP error with an
+            # AttributeError when the body isn't a dict.
             try:
                 error_body = res.json()
-                message = error_body.get("message", str(error_body))
+                if isinstance(error_body, dict):
+                    message = error_body.get("message", str(error_body))
+                else:
+                    message = str(error_body)
             except ValueError:
                 message = res.text or res.reason
 
@@ -4817,6 +4823,396 @@ class EclipseV2(EclipseBase):
             dict: Banner-spinner status
         """
         res = self.api_request(f"{self.base_url_v2}/Analytics/BannerSpinner/Status")
+        return res.json()
+
+    # --- Trading / TradeInstance (v2-only): the richer v2 instance surface -------
+    # Named with a ``trading_`` prefix to stay distinct from the v1
+    # ``get_trade_instance(s)`` methods, which hit the separate /tradeorder surface.
+
+    def get_trading_instances(
+        self,
+        trade_instance_id=None,
+        advisor_external_id=None,
+        is_enabled=None,
+        is_deleted=None,
+    ):
+        """Get trade instance(s) from the v2 Trading surface.
+
+        Args:
+            trade_instance_id: Optional trade-instance ID (maps to ``tradeInstanceId``)
+            advisor_external_id: Optional advisor external ID (``advisorExternalId``)
+            is_enabled: Optional bool (maps to ``isEnabled``)
+            is_deleted: Optional bool (maps to ``isDeleted``)
+
+        Returns:
+            list | dict: Trade instance(s)
+        """
+        params = {}
+        if trade_instance_id is not None:
+            params["tradeInstanceId"] = trade_instance_id
+        if advisor_external_id is not None:
+            params["advisorExternalId"] = advisor_external_id
+        if is_enabled is not None:
+            params["isEnabled"] = str(is_enabled).lower()
+        if is_deleted is not None:
+            params["isDeleted"] = str(is_deleted).lower()
+        res = self.api_request(f"{self.base_url_v2}/Trading/TradeInstance", params=params)
+        return res.json()
+
+    def get_trading_instance_trades(self, trade_instance_id):
+        """Get the trades for a v2 trade instance.
+
+        Args:
+            trade_instance_id: Trade-instance ID
+
+        Returns:
+            list: Trade dicts
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Trading/TradeInstance/{trade_instance_id}/Trades"
+        )
+        return res.json()
+
+    def get_trading_instances_for_user(self, start_date, end_date, offset=None, limit=None):
+        """Get trade instances for portfolios accessible to the user, by date range.
+
+        Args:
+            start_date: Start date (ISO YYYY-MM-DD; maps to ``startDate``)
+            end_date: End date (ISO YYYY-MM-DD; maps to ``endDate``)
+            offset: Optional paging offset
+            limit: Optional paging limit
+
+        Returns:
+            list: Trade instance dicts
+        """
+        params = {"startDate": start_date, "endDate": end_date}
+        if offset is not None:
+            params["offset"] = offset
+        if limit is not None:
+            params["limit"] = limit
+        res = self.api_request(f"{self.base_url_v2}/Trading/TradeInstance/ForUser", params=params)
+        return res.json()
+
+    def get_trading_instances_by_date_range(self, start_date, end_date):
+        """Get the trade-instance grid for a date range.
+
+        Args:
+            start_date: Start date (ISO YYYY-MM-DD)
+            end_date: End date (ISO YYYY-MM-DD)
+
+        Returns:
+            list: Trade instance dicts
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Trading/TradeInstance/GetByDateRange",
+            params={"startDate": start_date, "endDate": end_date},
+        )
+        return res.json()
+
+    def get_trading_instances_paginated(
+        self,
+        start_date=None,
+        end_date=None,
+        portfolio_id=None,
+        external_firm_id=None,
+        external_account_id=None,
+        skip=None,
+        take=None,
+    ):
+        """Get a paginated list of trade instances (without trades) plus a total count.
+
+        Note:
+            Eclipse requires a scoping filter — pass ``portfolio_id`` (or the
+            external firm/account IDs). A date window alone returns
+            ``400 'Unable to retrieve trade instances'``.
+
+        Args:
+            start_date / end_date: Optional ISO date window
+            portfolio_id: Portfolio filter (maps to ``portfolioId``)
+            external_firm_id: Optional external firm ID (``externalFirmId``)
+            external_account_id: Optional external account ID (``externalAccountId``)
+            skip / take: Optional paging window
+
+        Returns:
+            dict: Paginated result with ``data`` (instances) and ``total`` count
+        """
+        params = {}
+        for key, val in (
+            ("startDate", start_date),
+            ("endDate", end_date),
+            ("portfolioId", portfolio_id),
+            ("externalFirmId", external_firm_id),
+            ("externalAccountId", external_account_id),
+            ("skip", skip),
+            ("take", take),
+        ):
+            if val is not None:
+                params[key] = val
+        res = self.api_request(f"{self.base_url_v2}/Trading/TradeInstance/Paginated", params=params)
+        return res.json()
+
+    def get_trading_instances_with_trades(
+        self,
+        portfolio_id=None,
+        start_date=None,
+        end_date=None,
+        order_status=None,
+        skip=None,
+        take=None,
+    ):
+        """Get a paginated list of trade instances including their trades.
+
+        Args:
+            portfolio_id: Optional portfolio filter (maps to ``portfolioId``)
+            start_date / end_date: Optional ISO date window
+            order_status: Optional order-status filter (``orderStatus``)
+            skip / take: Optional paging window
+
+        Returns:
+            dict: Paginated result with instances + trades
+        """
+        params = {}
+        for key, val in (
+            ("portfolioId", portfolio_id),
+            ("startDate", start_date),
+            ("endDate", end_date),
+            ("orderStatus", order_status),
+            ("skip", skip),
+            ("take", take),
+        ):
+            if val is not None:
+                params[key] = val
+        res = self.api_request(
+            f"{self.base_url_v2}/Trading/TradeInstance/WithTrades", params=params
+        )
+        return res.json()
+
+    def get_trading_active_batch_jobs(self, start_date=None, end_date=None):
+        """Get active batch-job entries for the user.
+
+        Args:
+            start_date / end_date: Optional ISO date window
+
+        Returns:
+            list: Active batch-job dicts
+        """
+        params = {}
+        if start_date is not None:
+            params["startDate"] = start_date
+        if end_date is not None:
+            params["endDate"] = end_date
+        res = self.api_request(f"{self.base_url_v2}/Trading/ActiveBatchJobs", params=params)
+        return res.json()
+
+    # --- Optimization (v2-only): per-batch / per-account detail reads ------------
+
+    def get_optimization_accounts(self, batch_id):
+        """Get the current state of accounts in an optimization batch.
+
+        Args:
+            batch_id: Optimization batch ID
+
+        Returns:
+            list: Account-state dicts
+        """
+        res = self.api_request(f"{self.base_url_v2}/Optimization/accounts/{batch_id}")
+        return res.json()
+
+    def get_optimization_account_summary(self, batch_id, account_id=None):
+        """Get the optimization summary (and holdings) for an account in a batch.
+
+        Args:
+            batch_id: Optimization batch ID
+            account_id: Optional account ID (maps to ``accountId``)
+
+        Returns:
+            dict: Optimization summary
+        """
+        params = {}
+        if account_id is not None:
+            params["accountId"] = account_id
+        res = self.api_request(
+            f"{self.base_url_v2}/Optimization/summaries/{batch_id}", params=params
+        )
+        return res.json()
+
+    def get_optimization_batch_account_summaries(self, batch_id):
+        """Get every optimization summary belonging to a batch (one row per account).
+
+        Args:
+            batch_id: Optimization batch ID
+
+        Returns:
+            list: Optimization summary dicts
+        """
+        res = self.api_request(f"{self.base_url_v2}/Optimization/summaries/batch/{batch_id}")
+        return res.json()
+
+    def get_optimization_account_messages(self, batch_id, account_id=None):
+        """Get optimizer-emitted messages for an account in a batch.
+
+        Args:
+            batch_id: Optimization batch ID
+            account_id: Optional account ID (maps to ``accountId``)
+
+        Returns:
+            list: Optimizer message dicts
+        """
+        params = {}
+        if account_id is not None:
+            params["accountId"] = account_id
+        res = self.api_request(
+            f"{self.base_url_v2}/Optimization/summaries/{batch_id}/messages", params=params
+        )
+        return res.json()
+
+    def get_optimization_log(self, connect_account_id=None, batch_name=None, connect_firm_id=None):
+        """Get the optimization log.
+
+        Args:
+            connect_account_id: Optional Orion Connect account ID (``connectAccountId``)
+            batch_name: Optional batch name (``batchName``)
+            connect_firm_id: Optional Orion Connect firm ID (``connectFirmId``)
+
+        Returns:
+            dict | list: Optimization log
+        """
+        params = {}
+        if connect_account_id is not None:
+            params["connectAccountId"] = connect_account_id
+        if batch_name is not None:
+            params["batchName"] = batch_name
+        if connect_firm_id is not None:
+            params["connectFirmId"] = connect_firm_id
+        res = self.api_request(f"{self.base_url_v2}/Optimization/Log", params=params)
+        return res.json()
+
+    def get_optimization_holdings_target(self, account_id, batch_name=None, al_client_id=None):
+        """Get the holdings and target strategies for an account in a batch.
+
+        Args:
+            account_id: Account ID
+            batch_name: Optional batch name (``batchName``)
+            al_client_id: Optional AL client ID (``alClientId``)
+
+        Returns:
+            dict: Holdings + target strategies
+        """
+        params = {}
+        if batch_name is not None:
+            params["batchName"] = batch_name
+        if al_client_id is not None:
+            params["alClientId"] = al_client_id
+        res = self.api_request(
+            f"{self.base_url_v2}/Optimization/HoldingsTarget/{account_id}", params=params
+        )
+        return res.json()
+
+    # --- SavedView (v2-only) -----------------------------------------------------
+
+    def get_saved_views(self, view_type_id, name=None):
+        """Get the current user's saved views for a view type.
+
+        Args:
+            view_type_id: View-type ID
+            name: Optional name filter (maps to ``name``)
+
+        Returns:
+            list: Saved-view dicts
+        """
+        params = {}
+        if name is not None:
+            params["name"] = name
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/ViewType/{view_type_id}", params=params
+        )
+        return res.json()
+
+    def get_saved_views_ranked(self, view_type_id, simple_views=None, filter_required=None):
+        """Get the user's saved views for a view type, including rank/order.
+
+        Args:
+            view_type_id: View-type ID
+            simple_views: Optional bool (maps to ``simpleViews``)
+            filter_required: Optional bool (maps to ``filterRequired``)
+
+        Returns:
+            list: Ranked saved-view dicts
+        """
+        params = {}
+        if simple_views is not None:
+            params["simpleViews"] = str(simple_views).lower()
+        if filter_required is not None:
+            params["filterRequired"] = str(filter_required).lower()
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/ViewType/{view_type_id}/Rank", params=params
+        )
+        return res.json()
+
+    def execute_saved_view(self, view_id):
+        """Execute a saved view and return the number of records.
+
+        Args:
+            view_id: Saved-view ID
+
+        Returns:
+            dict: Execution result (record count)
+        """
+        res = self.api_request(f"{self.base_url_v2}/SavedView/Execute/{view_id}")
+        return res.json()
+
+    # --- Notes (v2-only) ---------------------------------------------------------
+
+    def get_notes(self, related_type, related_id):
+        """Get the notes for a related entity.
+
+        Args:
+            related_type: Related entity type (maps to ``relatedType``)
+            related_id: Related entity ID (maps to ``relatedId``)
+
+        Returns:
+            list: Note dicts
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Notes",
+            params={"relatedType": related_type, "relatedId": related_id},
+        )
+        return res.json()
+
+    def get_notes_history(self, related_type, related_id, from_date=None, to_date=None):
+        """Get notes history for a related entity.
+
+        Args:
+            related_type: Related entity type (maps to ``relatedType``)
+            related_id: Related entity ID (maps to ``relatedId``)
+            from_date: Optional start date (``fromDate``)
+            to_date: Optional end date (``toDate``)
+
+        Returns:
+            list: Note-history dicts
+        """
+        params = {"relatedType": related_type, "relatedId": related_id}
+        if from_date is not None:
+            params["fromDate"] = from_date
+        if to_date is not None:
+            params["toDate"] = to_date
+        res = self.api_request(f"{self.base_url_v2}/Notes/History", params=params)
+        return res.json()
+
+    def get_note_related_entities(self, entity_id, entity_type):
+        """Get entities related to a primary entity (for notes).
+
+        Args:
+            entity_id: Primary entity ID (maps to ``entityId``)
+            entity_type: Primary entity type (maps to ``entityType``)
+
+        Returns:
+            list: Related-entity dicts
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Notes/RelatedEntities",
+            params={"entityId": entity_id, "entityType": entity_type},
+        )
         return res.json()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.2.0"
+version = "2.3.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1121,3 +1121,186 @@ class TestEclipseUnifierV2Fallback:
         api = Eclipse(eclipse_token="tok")
         # get_account_holdings exists on v1 -> delegated to v1, not v2
         assert api.get_account_holdings.__self__ is api.v1
+
+
+class TestEclipseV2ReadEndpointsBatch2:
+    """URL/params coverage for v2 reads: Trading instances, Optimization, SavedView, Notes."""
+
+    # --- Trading / TradeInstance ---
+
+    def test_trading_instances_filters(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_trading_instances(trade_instance_id=5, is_enabled=True, is_deleted=False)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/TradeInstance"
+        assert mock_get.call_args.kwargs["params"] == {
+            "tradeInstanceId": 5,
+            "isEnabled": "true",
+            "isDeleted": "false",
+        }
+
+    def test_trading_instance_trades(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_trading_instance_trades(88)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/TradeInstance/88/Trades"
+
+    def test_trading_instances_for_user(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_trading_instances_for_user("2026-01-01", "2026-01-31", offset=0, limit=50)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/TradeInstance/ForUser"
+        assert mock_get.call_args.kwargs["params"] == {
+            "startDate": "2026-01-01",
+            "endDate": "2026-01-31",
+            "offset": 0,
+            "limit": 50,
+        }
+
+    def test_trading_instances_by_date_range(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_trading_instances_by_date_range("2026-01-01", "2026-01-31")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/TradeInstance/GetByDateRange"
+        assert mock_get.call_args.kwargs["params"] == {
+            "startDate": "2026-01-01",
+            "endDate": "2026-01-31",
+        }
+
+    def test_trading_instances_paginated(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_trading_instances_paginated(portfolio_id=3, skip=0, take=25)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/TradeInstance/Paginated"
+        assert mock_get.call_args.kwargs["params"] == {"portfolioId": 3, "skip": 0, "take": 25}
+
+    def test_trading_instances_with_trades(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_trading_instances_with_trades(portfolio_id=3, order_status="Pending")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/TradeInstance/WithTrades"
+        assert mock_get.call_args.kwargs["params"] == {"portfolioId": 3, "orderStatus": "Pending"}
+
+    def test_trading_active_batch_jobs(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_trading_active_batch_jobs()
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Trading/ActiveBatchJobs"
+        assert mock_get.call_args.kwargs["params"] == {}
+
+    # --- Optimization detail ---
+
+    def test_optimization_accounts(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_optimization_accounts("batch-1")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Optimization/accounts/batch-1"
+
+    def test_optimization_account_summary(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_optimization_account_summary("batch-1", account_id=9)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Optimization/summaries/batch-1"
+        assert mock_get.call_args.kwargs["params"] == {"accountId": 9}
+
+    def test_optimization_batch_account_summaries(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_optimization_batch_account_summaries("batch-1")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Optimization/summaries/batch/batch-1"
+
+    def test_optimization_account_messages(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_optimization_account_messages("batch-1", account_id=9)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Optimization/summaries/batch-1/messages"
+        assert mock_get.call_args.kwargs["params"] == {"accountId": 9}
+
+    def test_optimization_log(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_optimization_log(connect_account_id=1, batch_name="b", connect_firm_id=2)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Optimization/Log"
+        assert mock_get.call_args.kwargs["params"] == {
+            "connectAccountId": 1,
+            "batchName": "b",
+            "connectFirmId": 2,
+        }
+
+    def test_optimization_holdings_target(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_optimization_holdings_target(9, batch_name="b")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Optimization/HoldingsTarget/9"
+        assert mock_get.call_args.kwargs["params"] == {"batchName": "b"}
+
+    # --- SavedView ---
+
+    def test_saved_views(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_saved_views(4, name="My View")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/SavedView/ViewType/4"
+        assert mock_get.call_args.kwargs["params"] == {"name": "My View"}
+
+    def test_saved_views_ranked(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_saved_views_ranked(4, simple_views=True, filter_required=False)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/SavedView/ViewType/4/Rank"
+        assert mock_get.call_args.kwargs["params"] == {
+            "simpleViews": "true",
+            "filterRequired": "false",
+        }
+
+    def test_execute_saved_view(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.execute_saved_view(123)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/SavedView/Execute/123"
+
+    # --- Notes ---
+
+    def test_get_notes(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_notes("Portfolio", 7)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Notes"
+        assert mock_get.call_args.kwargs["params"] == {"relatedType": "Portfolio", "relatedId": 7}
+
+    def test_get_notes_history(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_notes_history("Portfolio", 7, from_date="2026-01-01")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Notes/History"
+        assert mock_get.call_args.kwargs["params"] == {
+            "relatedType": "Portfolio",
+            "relatedId": 7,
+            "fromDate": "2026-01-01",
+        }
+
+    def test_get_note_related_entities(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_note_related_entities(7, "Portfolio")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Notes/RelatedEntities"
+        assert mock_get.call_args.kwargs["params"] == {"entityId": 7, "entityType": "Portfolio"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1089,3 +1089,60 @@ class TestEclipseV2CoverageBatch1:
         # v2-only method reachable directly on the unifier (falls through to .v2)
         pid = self._first_portfolio_id(eclipse_client)
         assert isinstance(eclipse_client.get_tactical_portfolio_summary(pid), dict)
+
+
+class TestEclipseV2CoverageBatch2:
+    """Live smoke tests for v2 Trading/TradeInstance reads (coverage batch 2).
+
+    Optimization reads are role-gated (OPTIMIZER) and Notes needs a valid
+    relatedType enum, so those are covered by unit tests only.
+    """
+
+    def _date_window(self):
+        from datetime import datetime, timedelta
+
+        today = datetime.now()
+        return (today - timedelta(days=120)).strftime("%Y-%m-%d"), today.strftime("%Y-%m-%d")
+
+    def test_trading_instances_by_date_range(self, eclipse_client):
+        sd, ed = self._date_window()
+        assert isinstance(eclipse_client.v2.get_trading_instances_by_date_range(sd, ed), list)
+
+    def test_trading_instances_for_user(self, eclipse_client):
+        sd, ed = self._date_window()
+        result = eclipse_client.v2.get_trading_instances_for_user(sd, ed, offset=0, limit=10)
+        assert isinstance(result, list)
+
+    def test_trading_instances_with_trades(self, eclipse_client):
+        sd, ed = self._date_window()
+        result = eclipse_client.v2.get_trading_instances_with_trades(
+            start_date=sd, end_date=ed, take=5
+        )
+        assert isinstance(result, (list, dict))
+
+    def test_trading_active_batch_jobs(self, eclipse_client):
+        sd, ed = self._date_window()
+        assert isinstance(
+            eclipse_client.v2.get_trading_active_batch_jobs(start_date=sd, end_date=ed), list
+        )
+
+    def test_trading_instances_paginated_by_portfolio(self, eclipse_client):
+        portfolios = eclipse_client.v1.get_all_portfolios(top=1)
+        if not portfolios:
+            pytest.skip("No portfolios available")
+        result = eclipse_client.v2.get_trading_instances_paginated(
+            portfolio_id=portfolios[0]["id"], take=5
+        )
+        # Eclipse returns {"data": [...], "total": N}
+        assert isinstance(result, dict)
+        assert "data" in result
+
+    def test_trading_instance_trades(self, eclipse_client):
+        sd, ed = self._date_window()
+        instances = eclipse_client.v2.get_trading_instances_by_date_range(sd, ed)
+        if not instances:
+            pytest.skip("No trade instances in window")
+        inst_id = instances[0].get("id") or instances[0].get("tradeInstanceId")
+        if not inst_id:
+            pytest.skip("No trade-instance id field found")
+        assert isinstance(eclipse_client.v2.get_trading_instance_trades(inst_id), list)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -368,6 +368,50 @@ class TestAPIErrors:
                 with pytest.raises(OrionAPIError, match="HTML error page"):
                     api.api_request("http://test.com", req_func=mock_req)
 
+    def test_error_with_json_string_body(self):
+        """Error body that is a bare JSON string must not raise AttributeError.
+
+        Regression: some Eclipse v2 endpoints return a plain JSON string on 400
+        (e.g. "Unable to retrieve trade instances"). The error handler used to call
+        .get() on it unconditionally, masking the real HTTP error with an
+        AttributeError. It must surface the string as the message instead.
+        """
+        with patch.object(OrionAPI, "login"):
+            api = OrionAPI(usr="test", pwd="pass")
+
+            mock_response = Mock()
+            mock_response.ok = False
+            mock_response.status_code = 400
+            mock_response.reason = "Bad Request"
+            mock_response.json.return_value = "Unable to retrieve trade instances"
+            mock_req = Mock(return_value=mock_response)
+
+            with (
+                patch.object(api._rate_limiter, "wait"),
+                patch.object(api, "_get_auth_header", return_value={}),
+            ):
+                with pytest.raises(OrionAPIError, match="Unable to retrieve trade instances"):
+                    api.api_request("http://test.com", req_func=mock_req)
+
+    def test_error_with_json_list_body(self):
+        """Error body that is a JSON list must surface as the message, not crash."""
+        with patch.object(OrionAPI, "login"):
+            api = OrionAPI(usr="test", pwd="pass")
+
+            mock_response = Mock()
+            mock_response.ok = False
+            mock_response.status_code = 400
+            mock_response.reason = "Bad Request"
+            mock_response.json.return_value = ["id is not numeric string "]
+            mock_req = Mock(return_value=mock_response)
+
+            with (
+                patch.object(api._rate_limiter, "wait"),
+                patch.object(api, "_get_auth_header", return_value={}),
+            ):
+                with pytest.raises(OrionAPIError, match="id is not numeric string"):
+                    api.api_request("http://test.com", req_func=mock_req)
+
 
 class TestInputValidation:
     """Test input validation for search methods."""


### PR DESCRIPTION
## Context
Batch 2 of the phased v2-coverage effort (v2-only capabilities, reads first). Adds 19 `EclipseV2` read methods from `API Docs/EclipseV2Swagger.json`, plus a real error-handling bug fix surfaced during live verification.

## New `EclipseV2` read methods (19)
- **Trading / TradeInstance** (the richer v2 instance surface; `trading_` prefix keeps them distinct from the v1 `/tradeorder` `get_trade_instance(s)` methods): `get_trading_instances`, `get_trading_instance_trades`, `get_trading_instances_for_user`, `get_trading_instances_by_date_range`, `get_trading_instances_paginated`, `get_trading_instances_with_trades`, `get_trading_active_batch_jobs`
- **Optimization** (per-batch / per-account detail): `get_optimization_accounts`, `get_optimization_account_summary`, `get_optimization_batch_account_summaries`, `get_optimization_account_messages`, `get_optimization_log`, `get_optimization_holdings_target`
- **SavedView**: `get_saved_views`, `get_saved_views_ranked`, `execute_saved_view`
- **Notes**: `get_notes`, `get_notes_history`, `get_note_related_entities`

## Bug fix (affects all v1 + v2 calls)
`api_request` error handling called `error_body.get(...)` unconditionally. When an error response body is a **bare JSON string** (e.g. v2's `400 "Unable to retrieve trade instances"`), that raised `AttributeError` and **masked the real HTTP error**. Now guarded for dict vs string/list bodies, with regression tests for both shapes (string and list — the list case also covers the `securityset/detail` `['id is not numeric string ']` error).

## Verification
- Trading-instance reads **live-verified** (date-range returned 586 instances, instance-trades, with-trades, paginated all OK). `get_trading_instances_paginated` requires a `portfolio_id`/external scoping filter (date window alone 400s) — documented in the method.
- Optimization reads are **role-gated** (this tenant's role lacks OPTIMIZER read) and Notes needs a valid `relatedType` enum — both unit-tested only.
- Mocked unit tests for all 19 + 2 error-handling regression tests. New `TestEclipseV2CoverageBatch2` live class (6 passing). ruff clean; 146 unit/security pass + 6 live. Version 2.2.0 → 2.3.0.

## Coverage progress
Named coverage ~87 → ~106 endpoints. Remaining toward 50% of ~791: v2 re-exposed account/portfolio/security/preference reads, more modeling/model reads, then writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)