### PR TITLE
Eclipse v2 coverage batch 3: account/portfolio/sleeve/preference reads (2.4.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 import logging
 import re
@@ -5212,6 +5212,388 @@ class EclipseV2(EclipseBase):
         res = self.api_request(
             f"{self.base_url_v2}/Notes/RelatedEntities",
             params={"entityId": entity_id, "entityType": entity_type},
+        )
+        return res.json()
+
+    # --- Account detail (v2-only reads with no v1 equivalent) --------------------
+
+    def get_account_cash_details(self, account_id):
+        """Get cash details for an account.
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            dict: Cash details
+        """
+        res = self.api_request(f"{self.base_url_v2}/Account/Accounts/{account_id}/CashDetails")
+        return res.json()
+
+    def get_account_gain_loss_summary(self, account_id):
+        """Get the gain/loss summary for an account.
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            dict: Gain/loss summary
+        """
+        res = self.api_request(f"{self.base_url_v2}/Account/Accounts/{account_id}/GainLossSummary")
+        return res.json()
+
+    def get_account_history(self, account_id, from_date=None, to_date=None):
+        """Get account history.
+
+        Args:
+            account_id: Account ID
+            from_date / to_date: Optional ISO date window (``fromDate`` / ``toDate``)
+
+        Returns:
+            list: Account-history dicts
+        """
+        params = {}
+        if from_date is not None:
+            params["fromDate"] = from_date
+        if to_date is not None:
+            params["toDate"] = to_date
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/{account_id}/History", params=params
+        )
+        return res.json()
+
+    def get_account_model_history(self, account_id, from_date=None, to_date=None):
+        """Get an account's model history.
+
+        Args:
+            account_id: Account ID
+            from_date / to_date: Optional ISO date window (``fromDate`` / ``toDate``)
+
+        Returns:
+            list: Model-history dicts
+        """
+        params = {}
+        if from_date is not None:
+            params["fromDate"] = from_date
+        if to_date is not None:
+            params["toDate"] = to_date
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/{account_id}/ModelHistory", params=params
+        )
+        return res.json()
+
+    def get_account_transactions(self, account_id, start_date=None, end_date=None):
+        """Get account transactions over a date range.
+
+        Args:
+            account_id: Account ID
+            start_date / end_date: Optional ISO date window (``startDate`` / ``endDate``)
+
+        Returns:
+            list: Transaction dicts
+        """
+        params = {}
+        if start_date is not None:
+            params["startDate"] = start_date
+        if end_date is not None:
+            params["endDate"] = end_date
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/{account_id}/Transactions", params=params
+        )
+        return res.json()
+
+    def get_accessible_account_count(self):
+        """Get the count of accounts accessible to the authenticated user.
+
+        Returns:
+            int | dict: Accessible-account count
+        """
+        res = self.api_request(f"{self.base_url_v2}/Account/Accounts/AccessibleCount")
+        return res.json()
+
+    def get_account_by_external(self, external_firm_id, external_account_id):
+        """Get an account by external firm + account ID.
+
+        Args:
+            external_firm_id: External firm ID
+            external_account_id: External account ID
+
+        Returns:
+            dict: Account detail
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/byexternal/"
+            f"{external_firm_id}/{external_account_id}"
+        )
+        return res.json()
+
+    # --- Astro accounts (v2-only) ------------------------------------------------
+
+    def get_astro_accounts(self, filter=None):
+        """Get Astro account values (including alert-determination data).
+
+        Args:
+            filter: Optional filter (maps to ``filter``; see
+                :meth:`get_astro_account_filters`)
+
+        Returns:
+            list: Astro-account dicts
+        """
+        params = {}
+        if filter is not None:
+            params["filter"] = filter
+        res = self.api_request(f"{self.base_url_v2}/Account/AstroAccounts", params=params)
+        return res.json()
+
+    def get_astro_account_filters(self):
+        """Get the filters usable in the Astro-accounts endpoint.
+
+        Returns:
+            list: Filter dicts
+        """
+        res = self.api_request(f"{self.base_url_v2}/Account/AstroAccounts/Filters")
+        return res.json()
+
+    def get_astro_account_securities_restrictions(self, account_id):
+        """Get Astro security restrictions for an account.
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            list: Security-restriction dicts
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/{account_id}/SecuritiesRestrictions"
+        )
+        return res.json()
+
+    def get_astro_account_investor_preferences(
+        self, account_id, strategy_name=None, al_client_id=None
+    ):
+        """Get Astro investor preferences for an account.
+
+        Args:
+            account_id: Account ID
+            strategy_name: Optional strategy name (``strategyName``)
+            al_client_id: Optional AL client ID (``alClientId``)
+
+        Returns:
+            dict: Investor preferences
+        """
+        params = {}
+        if strategy_name is not None:
+            params["strategyName"] = strategy_name
+        if al_client_id is not None:
+            params["alClientId"] = al_client_id
+        res = self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/{account_id}/InvestorPreferences",
+            params=params,
+        )
+        return res.json()
+
+    # --- Portfolio detail (v2-only reads) ----------------------------------------
+
+    def get_portfolio_allocations(self, portfolio_id):
+        """Get portfolio allocations.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Allocations with ``categories`` / ``classes`` and reserve cash
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/Allocations"
+        )
+        return res.json()
+
+    def get_portfolio_cash_details(self, portfolio_id):
+        """Get cash details for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Cash details
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/CashDetails/{portfolio_id}"
+        )
+        return res.json()
+
+    def get_portfolio_gain_loss_summary(self, portfolio_id):
+        """Get the gain/loss summary for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Gain/loss summary
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/GainLossSummary"
+        )
+        return res.json()
+
+    def get_portfolio_mac_history(self, portfolio_id, from_date=None, to_date=None):
+        """Get portfolio MAC (model-assignment-change) history.
+
+        Args:
+            portfolio_id: Portfolio ID
+            from_date / to_date: Optional ISO date window (``fromDate`` / ``toDate``)
+
+        Returns:
+            dict: MAC history with ``details`` and ``statuses``
+        """
+        params = {}
+        if from_date is not None:
+            params["fromDate"] = from_date
+        if to_date is not None:
+            params["toDate"] = to_date
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/MacHistory", params=params
+        )
+        return res.json()
+
+    def get_portfolio_auto_rebalance_history(self, portfolio_id, start_date=None, end_date=None):
+        """Get auto-rebalance history for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+            start_date / end_date: Optional ISO date window (``startDate`` / ``endDate``)
+
+        Returns:
+            list: Auto-rebalance-history dicts
+        """
+        params = {}
+        if start_date is not None:
+            params["startDate"] = start_date
+        if end_date is not None:
+            params["endDate"] = end_date
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/AutoRebalanceHistory",
+            params=params,
+        )
+        return res.json()
+
+    def get_portfolio_tree(self, portfolio_id=None, account_id=None):
+        """Get the portfolio/account hierarchy for a portfolio or account.
+
+        Args:
+            portfolio_id: Optional portfolio ID (maps to ``portfolioId``)
+            account_id: Optional account ID (maps to ``accountId``)
+
+        Returns:
+            dict: Portfolio/account tree
+        """
+        params = {}
+        if portfolio_id is not None:
+            params["portfolioId"] = portfolio_id
+        if account_id is not None:
+            params["accountId"] = account_id
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/PortfolioTree", params=params
+        )
+        return res.json()
+
+    def get_portfolio_search(self, search=None, include_value=None, limit=None, offset=None):
+        """Search firm portfolios (v2 paged search).
+
+        Args:
+            search: Optional search string
+            include_value: Optional bool (maps to ``includeValue``)
+            limit / offset: Optional paging window
+
+        Returns:
+            list: Portfolio dicts
+        """
+        params = {}
+        if search is not None:
+            params["search"] = search
+        if include_value is not None:
+            params["includeValue"] = str(include_value).lower()
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        res = self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/GetPortfolioSearch", params=params
+        )
+        return res.json()
+
+    def get_accessible_portfolio_count(self):
+        """Get the count of portfolios accessible to the authenticated user.
+
+        Returns:
+            int | dict: Accessible-portfolio count
+        """
+        res = self.api_request(f"{self.base_url_v2}/Portfolio/Portfolios/AccessibleCount")
+        return res.json()
+
+    def get_user_portfolio_ids(self):
+        """Get the portfolio IDs accessible to the authenticated user.
+
+        Returns:
+            list: Portfolio IDs
+        """
+        res = self.api_request(f"{self.base_url_v2}/Portfolio/Portfolios/GetUserPortfolioIds")
+        return res.json()
+
+    # --- Sleeves (v2-only) -------------------------------------------------------
+
+    def get_sleeve_allocations(self, account_id):
+        """Get sleeve allocation details for an account.
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            dict: Sleeve allocations with ``categories`` / ``classes`` and reserve cash
+        """
+        res = self.api_request(f"{self.base_url_v2}/Portfolio/Sleeves/{account_id}/Allocations")
+        return res.json()
+
+    def get_sleeve_strategies(self):
+        """Get all sleeve strategies.
+
+        Returns:
+            list: Sleeve-strategy dicts
+        """
+        res = self.api_request(f"{self.base_url_v2}/Portfolio/Sleeves/SleeveStrategies")
+        return res.json()
+
+    def get_sleeve_contribution_methods(self):
+        """Get all sleeve contribution methods.
+
+        Returns:
+            list: Contribution-method dicts
+        """
+        res = self.api_request(f"{self.base_url_v2}/Portfolio/Sleeves/SleeveContributionMethods")
+        return res.json()
+
+    def get_sleeve_distribution_methods(self):
+        """Get all sleeve distribution methods.
+
+        Returns:
+            list: Distribution-method dicts
+        """
+        res = self.api_request(f"{self.base_url_v2}/Portfolio/Sleeves/SleeveDistributionMethods")
+        return res.json()
+
+    # --- Preference (v2-only) ----------------------------------------------------
+
+    def get_preference(self, preference_name):
+        """Get the value of a named preference.
+
+        Args:
+            preference_name: Preference name (maps to ``preferenceName``)
+
+        Returns:
+            dict: Preference value
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Preference/Preference/GetPreference",
+            params={"preferenceName": preference_name},
         )
         return res.json()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.3.0"
+version = "2.4.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1304,3 +1304,223 @@ class TestEclipseV2ReadEndpointsBatch2:
             api.get_note_related_entities(7, "Portfolio")
         assert mock_get.call_args.args[0] == f"{V2_BASE}/Notes/RelatedEntities"
         assert mock_get.call_args.kwargs["params"] == {"entityId": 7, "entityType": "Portfolio"}
+
+
+class TestEclipseV2ReadEndpointsBatch3:
+    """URL/params coverage for v2 account / portfolio / sleeve / preference reads."""
+
+    # --- Account detail ---
+
+    def test_account_cash_details(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_account_cash_details(57)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/57/CashDetails"
+
+    def test_account_gain_loss_summary(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_account_gain_loss_summary(57)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/57/GainLossSummary"
+
+    def test_account_history_params(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_account_history(57, from_date="2026-01-01", to_date="2026-02-01")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/57/History"
+        assert mock_get.call_args.kwargs["params"] == {
+            "fromDate": "2026-01-01",
+            "toDate": "2026-02-01",
+        }
+
+    def test_account_model_history(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_account_model_history(57)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/57/ModelHistory"
+        assert mock_get.call_args.kwargs["params"] == {}
+
+    def test_account_transactions(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_account_transactions(57, start_date="2026-01-01", end_date="2026-02-01")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/57/Transactions"
+        assert mock_get.call_args.kwargs["params"] == {
+            "startDate": "2026-01-01",
+            "endDate": "2026-02-01",
+        }
+
+    def test_accessible_account_count(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get(3)
+        with patch("requests.get", mock_get):
+            api.get_accessible_account_count()
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/AccessibleCount"
+
+    def test_account_by_external(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_account_by_external(11, 22)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/Accounts/byexternal/11/22"
+
+    # --- Astro accounts ---
+
+    def test_astro_accounts(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_astro_accounts(filter="alerts")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/AstroAccounts"
+        assert mock_get.call_args.kwargs["params"] == {"filter": "alerts"}
+
+    def test_astro_account_filters(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_astro_account_filters()
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Account/AstroAccounts/Filters"
+
+    def test_astro_account_securities_restrictions(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_astro_account_securities_restrictions(57)
+        assert mock_get.call_args.args[0] == (
+            f"{V2_BASE}/Account/AstroAccounts/57/SecuritiesRestrictions"
+        )
+
+    def test_astro_account_investor_preferences(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_astro_account_investor_preferences(57, strategy_name="Core")
+        assert mock_get.call_args.args[0] == (
+            f"{V2_BASE}/Account/AstroAccounts/57/InvestorPreferences"
+        )
+        assert mock_get.call_args.kwargs["params"] == {"strategyName": "Core"}
+
+    # --- Portfolio detail ---
+
+    def test_portfolio_allocations(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_portfolio_allocations(7)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7/Allocations"
+
+    def test_portfolio_cash_details(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_portfolio_cash_details(7)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/CashDetails/7"
+
+    def test_portfolio_gain_loss_summary(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_portfolio_gain_loss_summary(7)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7/GainLossSummary"
+
+    def test_portfolio_mac_history(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_portfolio_mac_history(7, from_date="2026-01-01")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7/MacHistory"
+        assert mock_get.call_args.kwargs["params"] == {"fromDate": "2026-01-01"}
+
+    def test_portfolio_auto_rebalance_history(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_portfolio_auto_rebalance_history(7, start_date="2026-01-01")
+        assert mock_get.call_args.args[0] == (
+            f"{V2_BASE}/Portfolio/Portfolios/7/AutoRebalanceHistory"
+        )
+        assert mock_get.call_args.kwargs["params"] == {"startDate": "2026-01-01"}
+
+    def test_portfolio_tree(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_portfolio_tree(portfolio_id=7)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/PortfolioTree"
+        assert mock_get.call_args.kwargs["params"] == {"portfolioId": 7}
+
+    def test_portfolio_search(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_portfolio_search(search="Smith", include_value=True, limit=10, offset=0)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/GetPortfolioSearch"
+        assert mock_get.call_args.kwargs["params"] == {
+            "search": "Smith",
+            "includeValue": "true",
+            "limit": 10,
+            "offset": 0,
+        }
+
+    def test_accessible_portfolio_count(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get(5)
+        with patch("requests.get", mock_get):
+            api.get_accessible_portfolio_count()
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/AccessibleCount"
+
+    def test_user_portfolio_ids(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_user_portfolio_ids()
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/GetUserPortfolioIds"
+
+    # --- Sleeves ---
+
+    def test_sleeve_allocations(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_sleeve_allocations(57)
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Sleeves/57/Allocations"
+
+    def test_sleeve_strategies(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_sleeve_strategies()
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Portfolio/Sleeves/SleeveStrategies"
+
+    def test_sleeve_contribution_methods(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_sleeve_contribution_methods()
+        assert mock_get.call_args.args[0] == (
+            f"{V2_BASE}/Portfolio/Sleeves/SleeveContributionMethods"
+        )
+
+    def test_sleeve_distribution_methods(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_sleeve_distribution_methods()
+        assert mock_get.call_args.args[0] == (
+            f"{V2_BASE}/Portfolio/Sleeves/SleeveDistributionMethods"
+        )
+
+    # --- Preference ---
+
+    def test_get_preference(self):
+        api = _eclipse_for_set_asides()
+        mock_get = _mock_get({})
+        with patch("requests.get", mock_get):
+            api.get_preference("AllowWashSales")
+        assert mock_get.call_args.args[0] == f"{V2_BASE}/Preference/Preference/GetPreference"
+        assert mock_get.call_args.kwargs["params"] == {"preferenceName": "AllowWashSales"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1146,3 +1146,101 @@ class TestEclipseV2CoverageBatch2:
         if not inst_id:
             pytest.skip("No trade-instance id field found")
         assert isinstance(eclipse_client.v2.get_trading_instance_trades(inst_id), list)
+
+
+class TestEclipseV2CoverageBatch3:
+    """Live smoke tests for v2 account / portfolio / sleeve reads (coverage batch 3).
+
+    Sleeve strategies are role-gated (SLEEVES) and get_preference needs a valid
+    preference name, so those are unit-tested only.
+    """
+
+    def _account_id(self, client):
+        accounts = client.v1.get_all_accounts()
+        if not accounts:
+            pytest.skip("No accounts available")
+        return accounts[0]["id"]
+
+    def _portfolio_id(self, client):
+        portfolios = client.v1.get_all_portfolios(top=1)
+        if not portfolios:
+            pytest.skip("No portfolios available")
+        return portfolios[0]["id"]
+
+    # no-arg
+    def test_accessible_account_count(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_accessible_account_count(), int)
+
+    def test_accessible_portfolio_count(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_accessible_portfolio_count(), int)
+
+    def test_user_portfolio_ids(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_user_portfolio_ids(), list)
+
+    def test_sleeve_contribution_methods(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_sleeve_contribution_methods(), list)
+
+    def test_sleeve_distribution_methods(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_sleeve_distribution_methods(), list)
+
+    def test_astro_account_filters(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_astro_account_filters(), list)
+
+    def test_astro_accounts(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_astro_accounts(), list)
+
+    def test_portfolio_search(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_portfolio_search(limit=3), list)
+
+    # account-scoped
+    def test_account_cash_details(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_account_cash_details(self._account_id(eclipse_client)), dict
+        )
+
+    def test_account_gain_loss_summary(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_account_gain_loss_summary(self._account_id(eclipse_client)),
+            dict,
+        )
+
+    def test_account_history(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_account_history(self._account_id(eclipse_client)), list
+        )
+
+    def test_account_transactions(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_account_transactions(self._account_id(eclipse_client)), list
+        )
+
+    def test_sleeve_allocations(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_sleeve_allocations(self._account_id(eclipse_client)), dict
+        )
+
+    # portfolio-scoped
+    def test_portfolio_allocations(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_portfolio_allocations(self._portfolio_id(eclipse_client)), dict
+        )
+
+    def test_portfolio_cash_details(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_portfolio_cash_details(self._portfolio_id(eclipse_client)), dict
+        )
+
+    def test_portfolio_gain_loss_summary(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_portfolio_gain_loss_summary(self._portfolio_id(eclipse_client)),
+            dict,
+        )
+
+    def test_portfolio_mac_history(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_portfolio_mac_history(self._portfolio_id(eclipse_client)), dict
+        )
+
+    def test_portfolio_tree(self, eclipse_client):
+        pid = self._portfolio_id(eclipse_client)
+        assert isinstance(eclipse_client.v2.get_portfolio_tree(portfolio_id=pid), dict)


### PR DESCRIPTION
## Context
Batch 3 of the phased v2-coverage effort (v2-only, reads first). Adds 25 `EclipseV2` read methods for the account- and portfolio-detail surfaces that v1 doesn't expose. Implemented from `API Docs/EclipseV2Swagger.json` and live spot-checked.

## New `EclipseV2` read methods (25)
- **Account detail:** `get_account_cash_details`, `get_account_gain_loss_summary`, `get_account_history`, `get_account_model_history`, `get_account_transactions`, `get_accessible_account_count`, `get_account_by_external`
- **Astro accounts:** `get_astro_accounts`, `get_astro_account_filters`, `get_astro_account_securities_restrictions`, `get_astro_account_investor_preferences`
- **Portfolio detail:** `get_portfolio_allocations`, `get_portfolio_cash_details`, `get_portfolio_gain_loss_summary`, `get_portfolio_mac_history`, `get_portfolio_auto_rebalance_history`, `get_portfolio_tree`, `get_portfolio_search`, `get_accessible_portfolio_count`, `get_user_portfolio_ids`
- **Sleeves:** `get_sleeve_allocations`, `get_sleeve_strategies`, `get_sleeve_contribution_methods`, `get_sleeve_distribution_methods`
- **Preference:** `get_preference`

All names are distinct from the v1 methods, so they're reachable both on the `Eclipse` unifier and via `.v2`.

## Verification
- Live spot-checked: account/portfolio cash details, gain/loss summaries, allocations, portfolio tree, history, search, counts (587 accounts / 232 portfolios), sleeve methods — all return expected shapes. Three return-type docstrings corrected to `dict` (`portfolio_allocations`, `sleeve_allocations`, `portfolio_mac_history`).
- Role-gated on this tenant: `get_sleeve_strategies` (SLEEVES). `get_preference` needs a valid preference name. Both unit-tested only.
- Mocked unit tests for all 25; new `TestEclipseV2CoverageBatch3` live class (18 passing). ruff clean; 135 unit + 18 live pass. Version 2.3.0 → 2.4.0 (no PyPI release — releasing at the 50% milestone).

## Coverage progress
Named coverage ~106 → ~131 endpoints (~17%). Remaining toward 50% of ~791: modeling/model reads, security/securityset v2 reads, remaining preference/config/firm/team reads, then writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)