### PR TITLE
Eclipse v2 coverage batch 5 (writes): SavedView / Notes / Tags (2.6.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 import logging
 import re
@@ -5876,6 +5876,173 @@ class EclipseV2(EclipseBase):
         if category is not None:
             path += f"/Category/{category}"
         res = self.api_request(f"{self.base_url_v2}{path}")
+        return res.json()
+
+    # =========================================================================
+    # WRITE methods (mutating). Low-blast-radius user/UI state: SavedView, Notes,
+    # Tags. Bodies are passed through as documented DTOs so callers stay faithful
+    # to the Swagger. These are NOT executed in the integration suite.
+    # =========================================================================
+
+    # --- SavedView writes ---
+
+    def save_saved_view(self, view):
+        """Save (create/update) a saved view for a specific view id.
+
+        Args:
+            view: Saved-view DTO (request body)
+
+        Returns:
+            dict: Saved view
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/SavedViewByIdSave", requests.post, json=view
+        )
+        return res.json()
+
+    def delete_saved_view(self, view_id):
+        """Delete a saved view.
+
+        Args:
+            view_id: Saved-view ID
+        """
+        res = self.api_request(f"{self.base_url_v2}/SavedView/{view_id}", requests.delete)
+        return res.json()
+
+    def delete_saved_views(self, view_ids):
+        """Delete an array of saved views.
+
+        Args:
+            view_ids: List of saved-view IDs (request body)
+        """
+        res = self.api_request(f"{self.base_url_v2}/SavedView/Delete", requests.post, json=view_ids)
+        return res.json()
+
+    def add_saved_view_to_dashboard(self, view_id, is_firm_action_items=None):
+        """Add a saved view to the user-level dashboard.
+
+        Args:
+            view_id: Saved-view ID
+            is_firm_action_items: Optional bool (maps to ``isFirmActionItems``)
+
+        Returns:
+            dict: Result
+        """
+        params = {}
+        if is_firm_action_items is not None:
+            params["isFirmActionItems"] = str(is_firm_action_items).lower()
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/{view_id}/dashboard", requests.post, params=params
+        )
+        return res.json()
+
+    def set_default_saved_view(self, view_type_id, view_id):
+        """Set a view as the default view for a view type.
+
+        Args:
+            view_type_id: View-type ID
+            view_id: Saved-view ID
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/ViewType/{view_type_id}/DefaultView/{view_id}",
+            requests.post,
+        )
+        return res.json()
+
+    def save_saved_views_ranking(self, view_type_id, views):
+        """Save the ranking/order of saved views for a view type.
+
+        Args:
+            view_type_id: View-type ID
+            views: Ranked saved-view DTOs (request body)
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/ViewType/{view_type_id}/Rank",
+            requests.post,
+            json=views,
+        )
+        return res.json()
+
+    def get_saved_views_for_types(self, view_type_ids):
+        """Get the current user's saved views for an array of view types (POST query).
+
+        Args:
+            view_type_ids: List of view-type IDs (request body)
+
+        Returns:
+            list: Saved-view dicts
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/SavedView/ViewType", requests.post, json=view_type_ids
+        )
+        return res.json()
+
+    # --- Notes writes ---
+
+    def add_notes(self, notes):
+        """Create notes.
+
+        Args:
+            notes: List of note DTOs (request body)
+
+        Returns:
+            list | dict: Created notes
+        """
+        res = self.api_request(f"{self.base_url_v2}/Notes/AddList", requests.post, json=notes)
+        return res.json()
+
+    def update_notes(self, notes):
+        """Update notes.
+
+        Args:
+            notes: List of note DTOs (request body)
+
+        Returns:
+            list | dict: Updated notes
+        """
+        res = self.api_request(f"{self.base_url_v2}/Notes/UpdateList", requests.post, json=notes)
+        return res.json()
+
+    def delete_notes(self, notes):
+        """Delete notes (batch).
+
+        Args:
+            notes: List of note DTOs / IDs (request body)
+        """
+        res = self.api_request(f"{self.base_url_v2}/Notes/DeleteList", requests.post, json=notes)
+        return res.json()
+
+    def update_note(self, note_id, note):
+        """Update a single note.
+
+        Args:
+            note_id: Note ID
+            note: Note DTO (request body)
+
+        Returns:
+            dict: Updated note
+        """
+        res = self.api_request(f"{self.base_url_v2}/Notes/{note_id}", requests.put, json=note)
+        return res.json()
+
+    def delete_note(self, note_id):
+        """Delete a single note.
+
+        Args:
+            note_id: Note ID
+        """
+        res = self.api_request(f"{self.base_url_v2}/Notes/{note_id}", requests.delete)
+        return res.json()
+
+    # --- Tags writes ---
+
+    def delete_tag(self, tag):
+        """Delete a tag.
+
+        Args:
+            tag: Tag DTO / identifier (request body)
+        """
+        res = self.api_request(f"{self.base_url_v2}/Tags/delete", requests.post, json=tag)
         return res.json()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.5.0"
+version = "2.6.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1679,3 +1679,116 @@ class TestEclipseV2ReadEndpointsBatch4:
         assert mock_get.call_args.args[0] == (
             f"{V2_BASE}/Lookup/SmaAccountTypeRestrictions/Category/IRA"
         )
+
+
+class TestEclipseV2WriteEndpoints:
+    """Verb/URL/body coverage for v2 write methods (SavedView, Notes, Tags).
+
+    Mutating; asserted via mocked requests only (never executed live).
+    """
+
+    # --- SavedView ---
+
+    def test_save_saved_view(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({"id": 1})
+        with patch("requests.post", mock_post):
+            api.save_saved_view({"name": "V"})
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/SavedView/SavedViewByIdSave"
+        assert mock_post.call_args.kwargs["json"] == {"name": "V"}
+
+    def test_delete_saved_view(self):
+        api = _eclipse_for_set_asides()
+        mock_del = _mock_post({})
+        with patch("requests.delete", mock_del):
+            api.delete_saved_view(7)
+        assert mock_del.call_args.args[0] == f"{V2_BASE}/SavedView/7"
+
+    def test_delete_saved_views(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.delete_saved_views([1, 2, 3])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/SavedView/Delete"
+        assert mock_post.call_args.kwargs["json"] == [1, 2, 3]
+
+    def test_add_saved_view_to_dashboard(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.add_saved_view_to_dashboard(7, is_firm_action_items=True)
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/SavedView/7/dashboard"
+        assert mock_post.call_args.kwargs["params"] == {"isFirmActionItems": "true"}
+
+    def test_set_default_saved_view(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.set_default_saved_view(4, 7)
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/SavedView/ViewType/4/DefaultView/7"
+
+    def test_save_saved_views_ranking(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.save_saved_views_ranking(4, [{"id": 1, "rank": 1}])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/SavedView/ViewType/4/Rank"
+        assert mock_post.call_args.kwargs["json"] == [{"id": 1, "rank": 1}]
+
+    def test_get_saved_views_for_types(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post([])
+        with patch("requests.post", mock_post):
+            api.get_saved_views_for_types([1, 2])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/SavedView/ViewType"
+        assert mock_post.call_args.kwargs["json"] == [1, 2]
+
+    # --- Notes ---
+
+    def test_add_notes(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post([])
+        with patch("requests.post", mock_post):
+            api.add_notes([{"note": "hi", "relatedId": 1}])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/Notes/AddList"
+        assert mock_post.call_args.kwargs["json"] == [{"note": "hi", "relatedId": 1}]
+
+    def test_update_notes(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post([])
+        with patch("requests.post", mock_post):
+            api.update_notes([{"id": 1, "note": "x"}])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/Notes/UpdateList"
+
+    def test_delete_notes(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.delete_notes([1, 2])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/Notes/DeleteList"
+        assert mock_post.call_args.kwargs["json"] == [1, 2]
+
+    def test_update_note(self):
+        api = _eclipse_for_set_asides()
+        mock_put = _mock_post({"id": 9})
+        with patch("requests.put", mock_put):
+            api.update_note(9, {"note": "edit"})
+        assert mock_put.call_args.args[0] == f"{V2_BASE}/Notes/9"
+        assert mock_put.call_args.kwargs["json"] == {"note": "edit"}
+
+    def test_delete_note(self):
+        api = _eclipse_for_set_asides()
+        mock_del = _mock_post({})
+        with patch("requests.delete", mock_del):
+            api.delete_note(9)
+        assert mock_del.call_args.args[0] == f"{V2_BASE}/Notes/9"
+
+    # --- Tags ---
+
+    def test_delete_tag(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.delete_tag({"id": 3})
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/Tags/delete"
+        assert mock_post.call_args.kwargs["json"] == {"id": 3}


### PR DESCRIPTION
## Context
First **write** batch toward the 50%-of-~791 target. Per the agreed direction, this starts on mutating endpoints, beginning with the lowest-blast-radius ones (user/UI state). Implemented from `API Docs/EclipseV2Swagger.json`.

## Safety
Mutating endpoints are **not executed** in the integration suite. Each is covered by mocked unit tests asserting the HTTP verb (`post`/`put`/`delete`), URL, and request body. Request bodies are passed through as the documented DTOs, so callers stay faithful to the spec rather than relying on a possibly-wrong hard-coded schema.

## New `EclipseV2` write methods (13)
- **SavedView:** `save_saved_view`, `delete_saved_view`, `delete_saved_views`, `add_saved_view_to_dashboard`, `set_default_saved_view`, `save_saved_views_ranking`, `get_saved_views_for_types`
- **Notes:** `add_notes`, `update_notes`, `delete_notes`, `update_note`, `delete_note`
- **Tags:** `delete_tag`

## Verification
- 13 mocked unit tests (verb + URL + body); 202 unit/security pass; ruff clean. Version 2.5.0 → 2.6.0 (no PyPI release — releasing at the 50% milestone).

## Coverage progress
Named coverage ~151 → ~164 endpoints (~21%). Writes are now in scope; subsequent batches will continue through the higher-value/lower-risk writes (preference, ESG, dashboard, model/portfolio updates) before the heavier trade-execution and delete surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)