### PR TITLE
Eclipse v2 coverage batch 6 (writes): ESG / AssetClassification / Notifications (2.7.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 
 import logging
 import re
@@ -6043,6 +6043,197 @@ class EclipseV2(EclipseBase):
             tag: Tag DTO / identifier (request body)
         """
         res = self.api_request(f"{self.base_url_v2}/Tags/delete", requests.post, json=tag)
+        return res.json()
+
+    # --- ESG writes (mutating) ---
+
+    def create_esg_theme(self, theme):
+        """Create an ESG theme.
+
+        Args:
+            theme: ESG-theme DTO (request body)
+
+        Returns:
+            dict: Created theme
+        """
+        res = self.api_request(f"{self.base_url_v2}/ESG/Themes", requests.post, json=theme)
+        return res.json()
+
+    def update_esg_theme(self, theme):
+        """Update an ESG theme.
+
+        Args:
+            theme: ESG-theme DTO (request body)
+
+        Returns:
+            dict: Updated theme
+        """
+        res = self.api_request(f"{self.base_url_v2}/ESG/Themes", requests.put, json=theme)
+        return res.json()
+
+    def delete_esg_themes(self, themes):
+        """Delete ESG themes.
+
+        Args:
+            themes: List of ESG-theme DTOs / IDs (request body)
+        """
+        res = self.api_request(f"{self.base_url_v2}/ESG/Themes", requests.delete, json=themes)
+        return res.json()
+
+    def create_esg_assignments(self, assignments):
+        """Create ESG assignments.
+
+        Args:
+            assignments: List of ESG-assignment DTOs (request body)
+
+        Returns:
+            list | dict: Created assignments
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/ESG/Assignments", requests.post, json=assignments
+        )
+        return res.json()
+
+    def update_esg_restrictions_for_portfolio(self, restrictions):
+        """Update the ESG restrictions for a portfolio.
+
+        Args:
+            restrictions: ESG-restrictions DTO (request body)
+
+        Returns:
+            dict: Updated restrictions
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/ESG/ESGRestrictionsForPortfolio", requests.put, json=restrictions
+        )
+        return res.json()
+
+    # --- Asset classification writes (mutating) ---
+
+    def create_asset_classification_group(self, group):
+        """Create an asset-classification group.
+
+        Args:
+            group: Classification-group DTO (request body)
+
+        Returns:
+            dict: Created group
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/AssetClassification/ClassificationGroup",
+            requests.post,
+            json=group,
+        )
+        return res.json()
+
+    def update_asset_classification_group(self, group):
+        """Update an asset-classification group.
+
+        Args:
+            group: Classification-group DTO (request body)
+
+        Returns:
+            dict: Updated group
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/AssetClassification/ClassificationGroup",
+            requests.put,
+            json=group,
+        )
+        return res.json()
+
+    def delete_asset_classification_group(self, group_id):
+        """Delete an asset-classification group.
+
+        Args:
+            group_id: Classification-group ID
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/AssetClassification/ClassificationGroup/{group_id}",
+            requests.delete,
+        )
+        return res.json()
+
+    def classify_securities(self, classifications):
+        """Assign classifications to securities.
+
+        Args:
+            classifications: Security-classification DTO(s) (request body)
+
+        Returns:
+            dict: Result
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/AssetClassification/Security/Classifications",
+            requests.post,
+            json=classifications,
+        )
+        return res.json()
+
+    # --- Notification writes (mutating) ---
+
+    def create_notification(self, notification):
+        """Create a notification.
+
+        Args:
+            notification: Notification DTO (request body)
+
+        Returns:
+            dict: Created notification
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Notifications/Notification/CreateNotification",
+            requests.post,
+            json=notification,
+        )
+        return res.json()
+
+    def update_notification(self, notification):
+        """Update a notification.
+
+        Args:
+            notification: Notification DTO (request body)
+
+        Returns:
+            dict: Updated notification
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Notifications/Notification/UpdateNotification",
+            requests.put,
+            json=notification,
+        )
+        return res.json()
+
+    def send_notification(self, notification):
+        """Send a notification.
+
+        Args:
+            notification: Notification DTO (request body)
+
+        Returns:
+            dict: Result
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Notifications/Notification/SendNotification",
+            requests.post,
+            json=notification,
+        )
+        return res.json()
+
+    def send_trading_notification(self, notification):
+        """Send a trading notification.
+
+        Args:
+            notification: Trading-notification DTO (request body)
+
+        Returns:
+            dict: Result
+        """
+        res = self.api_request(
+            f"{self.base_url_v2}/Notifications/Notification/SendTradingNotification",
+            requests.post,
+            json=notification,
+        )
         return res.json()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.6.0"
+version = "2.7.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1792,3 +1792,124 @@ class TestEclipseV2WriteEndpoints:
             api.delete_tag({"id": 3})
         assert mock_post.call_args.args[0] == f"{V2_BASE}/Tags/delete"
         assert mock_post.call_args.kwargs["json"] == {"id": 3}
+
+
+class TestEclipseV2WriteEndpointsBatch6:
+    """Verb/URL/body coverage for v2 ESG / classification / notification writes.
+
+    Mutating; asserted via mocked requests only (never executed live).
+    """
+
+    # --- ESG ---
+
+    def test_create_esg_theme(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({"id": 1})
+        with patch("requests.post", mock_post):
+            api.create_esg_theme({"theme": "Clean"})
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/ESG/Themes"
+        assert mock_post.call_args.kwargs["json"] == {"theme": "Clean"}
+
+    def test_update_esg_theme(self):
+        api = _eclipse_for_set_asides()
+        mock_put = _mock_post({"id": 1})
+        with patch("requests.put", mock_put):
+            api.update_esg_theme({"id": 1, "theme": "Clean"})
+        assert mock_put.call_args.args[0] == f"{V2_BASE}/ESG/Themes"
+
+    def test_delete_esg_themes(self):
+        api = _eclipse_for_set_asides()
+        mock_del = _mock_post({})
+        with patch("requests.delete", mock_del):
+            api.delete_esg_themes([1, 2])
+        assert mock_del.call_args.args[0] == f"{V2_BASE}/ESG/Themes"
+        assert mock_del.call_args.kwargs["json"] == [1, 2]
+
+    def test_create_esg_assignments(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post([])
+        with patch("requests.post", mock_post):
+            api.create_esg_assignments([{"themeId": 1}])
+        assert mock_post.call_args.args[0] == f"{V2_BASE}/ESG/Assignments"
+        assert mock_post.call_args.kwargs["json"] == [{"themeId": 1}]
+
+    def test_update_esg_restrictions_for_portfolio(self):
+        api = _eclipse_for_set_asides()
+        mock_put = _mock_post({})
+        with patch("requests.put", mock_put):
+            api.update_esg_restrictions_for_portfolio({"portfolioId": 7})
+        assert mock_put.call_args.args[0] == f"{V2_BASE}/ESG/ESGRestrictionsForPortfolio"
+        assert mock_put.call_args.kwargs["json"] == {"portfolioId": 7}
+
+    # --- Asset classification ---
+
+    def test_create_asset_classification_group(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({"id": 1})
+        with patch("requests.post", mock_post):
+            api.create_asset_classification_group({"name": "G"})
+        assert mock_post.call_args.args[0] == (f"{V2_BASE}/AssetClassification/ClassificationGroup")
+
+    def test_update_asset_classification_group(self):
+        api = _eclipse_for_set_asides()
+        mock_put = _mock_post({"id": 1})
+        with patch("requests.put", mock_put):
+            api.update_asset_classification_group({"id": 1, "name": "G"})
+        assert mock_put.call_args.args[0] == (f"{V2_BASE}/AssetClassification/ClassificationGroup")
+
+    def test_delete_asset_classification_group(self):
+        api = _eclipse_for_set_asides()
+        mock_del = _mock_post({})
+        with patch("requests.delete", mock_del):
+            api.delete_asset_classification_group(5)
+        assert mock_del.call_args.args[0] == (
+            f"{V2_BASE}/AssetClassification/ClassificationGroup/5"
+        )
+
+    def test_classify_securities(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.classify_securities([{"securityId": 1, "groupId": 2}])
+        assert mock_post.call_args.args[0] == (
+            f"{V2_BASE}/AssetClassification/Security/Classifications"
+        )
+        assert mock_post.call_args.kwargs["json"] == [{"securityId": 1, "groupId": 2}]
+
+    # --- Notifications ---
+
+    def test_create_notification(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({"id": 1})
+        with patch("requests.post", mock_post):
+            api.create_notification({"message": "hi"})
+        assert mock_post.call_args.args[0] == (
+            f"{V2_BASE}/Notifications/Notification/CreateNotification"
+        )
+
+    def test_update_notification(self):
+        api = _eclipse_for_set_asides()
+        mock_put = _mock_post({"id": 1})
+        with patch("requests.put", mock_put):
+            api.update_notification({"id": 1, "message": "hi"})
+        assert mock_put.call_args.args[0] == (
+            f"{V2_BASE}/Notifications/Notification/UpdateNotification"
+        )
+
+    def test_send_notification(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.send_notification({"to": "u"})
+        assert mock_post.call_args.args[0] == (
+            f"{V2_BASE}/Notifications/Notification/SendNotification"
+        )
+
+    def test_send_trading_notification(self):
+        api = _eclipse_for_set_asides()
+        mock_post = _mock_post({})
+        with patch("requests.post", mock_post):
+            api.send_trading_notification({"to": "u"})
+        assert mock_post.call_args.args[0] == (
+            f"{V2_BASE}/Notifications/Notification/SendTradingNotification"
+        )


### PR DESCRIPTION
## Context
Second write batch toward the coverage target — config / firm-preference state, **no trade execution or approval**. Implemented from `API Docs/EclipseV2Swagger.json`.

## New `EclipseV2` write methods (13)
- **ESG:** `create_esg_theme`, `update_esg_theme`, `delete_esg_themes`, `create_esg_assignments`, `update_esg_restrictions_for_portfolio`
- **AssetClassification:** `create_asset_classification_group`, `update_asset_classification_group`, `delete_asset_classification_group`, `classify_securities`
- **Notifications:** `create_notification`, `update_notification`, `send_notification`, `send_trading_notification`

## Safety
Mutating; **not executed live**. Covered by mocked unit tests asserting HTTP verb (`post`/`put`/`delete`), URL, and body. Bodies passed through as documented DTOs.

## Verification
13 unit tests; 213 unit/security pass; ruff clean. Version 2.6.0 → 2.7.0 (no PyPI release — releasing at milestone).

## Coverage progress
Named coverage ~164 → ~177 (~22%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)