### PR TITLE
Eclipse v1 coverage batch 12: account/holding/portfolio reads (2.13.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.12.0"
+__version__ = "2.13.0"
 
 import logging
 import re
@@ -4386,6 +4386,307 @@ class EclipseV1(EclipseBase):
         result = res.json()
         self._maybe_wait_for_analytics(sync)
         return result
+
+    # =========================================================================
+    # v1 read coverage (account / holding / portfolio). Reference/lookup reads
+    # plus account & portfolio sub-resource reads. No trade execution/approval.
+    # =========================================================================
+
+    # --- Account reference + sub-resource reads ---
+
+    def get_account_filters(self):
+        """Get the available account filters.
+
+        Returns:
+            list: Account-filter dicts
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/accountfilters").json()
+
+    def get_accounts_without_portfolio(self):
+        """Get accounts not assigned to a portfolio.
+
+        Returns:
+            list: Account dicts
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/noPortfolio").json()
+
+    def get_account_model_types(self, account_id):
+        """Get the model types for an account.
+
+        Args:
+            account_id: Internal account ID
+
+        Returns:
+            list: Model-type dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/{account_id}/model/modelTypes"
+        ).json()
+
+    def get_account_submodels(self, account_id, model_type_id=None):
+        """Get the submodels for an account.
+
+        Args:
+            account_id: Internal account ID
+            model_type_id: Optional model-type filter (maps to ``modelTypeId``)
+
+        Returns:
+            list: Submodel dicts
+        """
+        params = {}
+        if model_type_id is not None:
+            params["modelTypeId"] = model_type_id
+        return self.api_request(
+            f"{self.base_url}/account/accounts/{account_id}/model/submodels", params=params
+        ).json()
+
+    def get_aside_cash_percent_calc_types(self):
+        """Get set-aside-cash percent calculation types.
+
+        Returns:
+            list: Calculation-type dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/accountSetAsidePercentCalculationType"
+        ).json()
+
+    def get_aside_cash_amount_types(self):
+        """Get set-aside-cash amount types.
+
+        Returns:
+            list: Amount-type dicts
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/asideCashAmountType").json()
+
+    def get_aside_cash_expiration_types(self):
+        """Get set-aside-cash expiration types.
+
+        Returns:
+            list: Expiration-type dicts
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/asideCashExpirationType").json()
+
+    def get_aside_cash_transaction_types(self):
+        """Get set-aside-cash transaction types.
+
+        Returns:
+            list: Transaction-type dicts
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/asideCashTransactionType").json()
+
+    def get_accounts_simple_by_type(self, account_type):
+        """Get a simple account list filtered by account type.
+
+        Args:
+            account_type: Account type
+
+        Returns:
+            list: Account dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/simpleList/type/{account_type}"
+        ).json()
+
+    def get_account_custodial_information(self, account_id):
+        """Get custodial information for an account.
+
+        Args:
+            account_id: Internal account ID
+
+        Returns:
+            dict: Custodial information
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/{account_id}/custodialInformation"
+        ).json()
+
+    def get_account_sma(self, account_id):
+        """Get SMA info for an account.
+
+        Args:
+            account_id: Internal account ID
+
+        Returns:
+            dict: SMA info
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/{account_id}/sma").json()
+
+    def get_restricted_plans(self):
+        """Get the restricted plans.
+
+        Returns:
+            list: Restricted-plan dicts
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/restrictedPlans").json()
+
+    def get_portfolio_account_count(self):
+        """Get the portfolio/account count.
+
+        .. note::
+            As of 2026-05 this documented endpoint returns
+            ``400 'id is not numeric string'`` on live Eclipse — the server routes
+            the ``portfolioAccountCount`` segment into ``/account/accounts/{id}``.
+            Kept faithful to the documented path, but the upstream route appears
+            broken (same class of issue as :meth:`get_security_set_details`).
+
+        Returns:
+            dict | int: Count
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/portfolioAccountCount").json()
+
+    def get_account_portfolio_id(self, account_id):
+        """Get the portfolio ID for an account.
+
+        Args:
+            account_id: Internal account ID
+
+        Returns:
+            dict | int: Portfolio ID
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/{account_id}/portfolioId").json()
+
+    # --- Holding reads ---
+
+    def get_holding(self, holding_id):
+        """Get a holding by ID.
+
+        Args:
+            holding_id: Holding ID
+
+        Returns:
+            dict: Holding
+        """
+        return self.api_request(f"{self.base_url}/holding/holdings/{holding_id}").json()
+
+    def get_holding_filters(self):
+        """Get the available holding filters.
+
+        Returns:
+            list: Holding-filter dicts
+        """
+        return self.api_request(f"{self.base_url}/holding/holdings/holdingfilters").json()
+
+    def get_holding_transactions(self, holding_id):
+        """Get transactions for a holding.
+
+        Args:
+            holding_id: Holding ID
+
+        Returns:
+            list: Transaction dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/holding/holdings/{holding_id}/transactions"
+        ).json()
+
+    def search_holdings(self, search):
+        """Search holdings by id or name.
+
+        Args:
+            search: Search string (id or name)
+
+        Returns:
+            list: Holding dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/holding/holdings", params={"search": search}
+        ).json()
+
+    # --- Portfolio reference + sub-resource reads ---
+
+    def get_portfolio_filters(self):
+        """Get the available portfolio filters.
+
+        Returns:
+            list: Portfolio-filter dicts
+        """
+        return self.api_request(f"{self.base_url}/portfolio/portfolios/portfolioFilters").json()
+
+    def get_portfolio_accounts_detailed(self, portfolio_id):
+        """Get detailed accounts for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            list: Detailed account dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/accounts/detailed"
+        ).json()
+
+    def get_portfolio_accounts_summary(self, portfolio_id):
+        """Get an account summary for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            list | dict: Account summary
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/accounts/summary"
+        ).json()
+
+    def get_portfolio_simple(self, portfolio_id):
+        """Get a lightweight portfolio record by ID.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Lightweight portfolio
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/simple/{portfolio_id}"
+        ).json()
+
+    def get_portfolio_set_asides(self, portfolio_id):
+        """Get set-aside cash for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            list: Set-aside dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/asidecash"
+        ).json()
+
+    def get_portfolio_pending_models(self, portfolio_id):
+        """Get pending models for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            list | dict: Pending models
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/pending/models"
+        ).json()
+
+    def get_portfolio_contribution_amount(self, portfolio_id):
+        """Get the contribution amount for a portfolio.
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Contribution amount
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/contributionamount"
+        ).json()
+
+    def get_sleeves(self):
+        """Get all sleeves (v1).
+
+        Returns:
+            list: Sleeve dicts
+        """
+        return self.api_request(f"{self.base_url}/portfolio/sleeves").json()
 
 
 class EclipseV2(EclipseBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.12.0"
+version = "2.13.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2979,3 +2979,122 @@ class TestEclipseV2BlockMetaRefBatch11:
     def test_sync_trade_analysis_report(self):
         m = self._p("post", lambda a: a.sync_trade_analysis_report({"x": 1}))
         assert m.call_args.args[0] == f"{V2_BASE}/TradeAnalysisReport/SyncTradeAnalysisReport"
+
+
+class TestEclipseV1ReadCoverageBatch12:
+    """URL/params coverage for v1 account/holding/portfolio reads (batch 12)."""
+
+    def _g(self, fn):
+        api = _eclipse_v1()
+        mock = _mock_get([])
+        with patch("requests.get", mock):
+            fn(api)
+        return mock
+
+    def test_account_filters(self):
+        m = self._g(lambda a: a.get_account_filters())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/accountfilters"
+
+    def test_accounts_without_portfolio(self):
+        m = self._g(lambda a: a.get_accounts_without_portfolio())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/noPortfolio"
+
+    def test_account_model_types(self):
+        m = self._g(lambda a: a.get_account_model_types(5))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/model/modelTypes"
+
+    def test_account_submodels(self):
+        m = self._g(lambda a: a.get_account_submodels(5, model_type_id=2))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/model/submodels"
+        assert m.call_args.kwargs["params"] == {"modelTypeId": 2}
+
+    def test_aside_cash_percent_calc_types(self):
+        m = self._g(lambda a: a.get_aside_cash_percent_calc_types())
+        assert m.call_args.args[0] == (
+            f"{V1_BASE}/account/accounts/accountSetAsidePercentCalculationType"
+        )
+
+    def test_aside_cash_amount_types(self):
+        m = self._g(lambda a: a.get_aside_cash_amount_types())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/asideCashAmountType"
+
+    def test_aside_cash_expiration_types(self):
+        m = self._g(lambda a: a.get_aside_cash_expiration_types())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/asideCashExpirationType"
+
+    def test_aside_cash_transaction_types(self):
+        m = self._g(lambda a: a.get_aside_cash_transaction_types())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/asideCashTransactionType"
+
+    def test_accounts_simple_by_type(self):
+        m = self._g(lambda a: a.get_accounts_simple_by_type("IRA"))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/simpleList/type/IRA"
+
+    def test_account_custodial_information(self):
+        m = self._g(lambda a: a.get_account_custodial_information(5))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/custodialInformation"
+
+    def test_account_sma(self):
+        m = self._g(lambda a: a.get_account_sma(5))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/sma"
+
+    def test_restricted_plans(self):
+        m = self._g(lambda a: a.get_restricted_plans())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/restrictedPlans"
+
+    def test_portfolio_account_count(self):
+        m = self._g(lambda a: a.get_portfolio_account_count())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/portfolioAccountCount"
+
+    def test_account_portfolio_id(self):
+        m = self._g(lambda a: a.get_account_portfolio_id(5))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/portfolioId"
+
+    def test_holding(self):
+        m = self._g(lambda a: a.get_holding(9))
+        assert m.call_args.args[0] == f"{V1_BASE}/holding/holdings/9"
+
+    def test_holding_filters(self):
+        m = self._g(lambda a: a.get_holding_filters())
+        assert m.call_args.args[0] == f"{V1_BASE}/holding/holdings/holdingfilters"
+
+    def test_holding_transactions(self):
+        m = self._g(lambda a: a.get_holding_transactions(9))
+        assert m.call_args.args[0] == f"{V1_BASE}/holding/holdings/9/transactions"
+
+    def test_search_holdings(self):
+        m = self._g(lambda a: a.search_holdings("AAPL"))
+        assert m.call_args.args[0] == f"{V1_BASE}/holding/holdings"
+        assert m.call_args.kwargs["params"] == {"search": "AAPL"}
+
+    def test_portfolio_filters(self):
+        m = self._g(lambda a: a.get_portfolio_filters())
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/portfolioFilters"
+
+    def test_portfolio_accounts_detailed(self):
+        m = self._g(lambda a: a.get_portfolio_accounts_detailed(7))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/accounts/detailed"
+
+    def test_portfolio_accounts_summary(self):
+        m = self._g(lambda a: a.get_portfolio_accounts_summary(7))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/accounts/summary"
+
+    def test_portfolio_simple(self):
+        m = self._g(lambda a: a.get_portfolio_simple(7))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/simple/7"
+
+    def test_portfolio_set_asides(self):
+        m = self._g(lambda a: a.get_portfolio_set_asides(7))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/asidecash"
+
+    def test_portfolio_pending_models(self):
+        m = self._g(lambda a: a.get_portfolio_pending_models(7))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/pending/models"
+
+    def test_portfolio_contribution_amount(self):
+        m = self._g(lambda a: a.get_portfolio_contribution_amount(7))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/contributionamount"
+
+    def test_sleeves(self):
+        m = self._g(lambda a: a.get_sleeves())
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/sleeves"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1406,3 +1406,35 @@ class TestEclipseV2OrgRefBatch10:
 
     def test_workflow_mcp_servers(self, eclipse_client):
         assert isinstance(eclipse_client.v2.get_workflow_mcp_servers(), list)
+
+
+class TestEclipseV1ReadCoverageBatch12:
+    """Live smoke tests for v1 reference/sub-resource reads (batch 12).
+
+    get_portfolio_account_count 400s upstream (route collision) and get_sleeves
+    is role-gated (SLEEVES), so those are unit-tested only.
+    """
+
+    def test_account_filters(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_account_filters(), list)
+
+    def test_aside_cash_amount_types(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_aside_cash_amount_types(), list)
+
+    def test_aside_cash_expiration_types(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_aside_cash_expiration_types(), list)
+
+    def test_aside_cash_transaction_types(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_aside_cash_transaction_types(), list)
+
+    def test_restricted_plans(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_restricted_plans(), list)
+
+    def test_holding_filters(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_holding_filters(), list)
+
+    def test_portfolio_filters(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_portfolio_filters(), (list, dict))
+
+    def test_accounts_without_portfolio(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_accounts_without_portfolio(), list)


### PR DESCRIPTION
Begin lifting v1 coverage (non-trade) toward a combined ~50%. 26 EclipseV1 read methods: account reference + sub-resource reads, holdings, portfolio reference/sub-resources. Names chosen to avoid collision with the v2 methods on the unifier. Live-verified the reference reads; get_portfolio_account_count 400s upstream (route collision, documented) and get_sleeves is role-gated (SLEEVES) so those are unit-tested only. 345 unit + 8 live pass; ruff clean. Version 2.12.0 -> 2.13.0. v1 coverage ~16% -> ~25%; combined ~40% -> ~43%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)