### PR TITLE
Eclipse coverage batch 15: deepen Accounts/Portfolios/Models & sec sets (2.16.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.15.0"
+__version__ = "2.16.0"
 
 import logging
 import re
@@ -5490,6 +5490,191 @@ class EclipseV1(EclipseBase):
             f"{self.base_url}/security/securityset/{set_id}", requests.delete
         ).json()
 
+    # =========================================================================
+    # Coverage batch 15 (v1): deepen Accounts / Portfolios / Models & sec sets.
+    # =========================================================================
+
+    def get_house_account(self, custodian_id):
+        """Get the house account for a custodian.
+
+        Args:
+            custodian_id: Custodian ID
+
+        Returns:
+            dict: House account
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/action/houseAccount/{custodian_id}"
+        ).json()
+
+    def get_new_account_template(self):
+        """Get a blank/new account template.
+
+        Returns:
+            dict: New-account template
+        """
+        return self.api_request(f"{self.base_url}/account/accounts/new").json()
+
+    def get_account_set_aside(self, account_id, aside_cash_id):
+        """Get a single account set-aside cash entry.
+
+        Args:
+            account_id: Internal account ID
+            aside_cash_id: Set-aside-cash ID
+
+        Returns:
+            dict: Set-aside entry
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/{account_id}/asidecash/{aside_cash_id}"
+        ).json()
+
+    def get_accounts_portfolio_ids_detail(self, body):
+        """Get portfolio-id detail for a set of accounts (POST-body read).
+
+        Args:
+            body: Account-IDs DTO (request body)
+
+        Returns:
+            list | dict: Portfolio-id detail
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/list/portfolioIdsDetail", requests.post, json=body
+        ).json()
+
+    def get_aside_cash_account_types(self):
+        """Get the set-aside-cash account types.
+
+        Returns:
+            list: Account-type dicts
+        """
+        return self.api_request(f"{self.base_url}/portfolio/portfolios/asideCashAccountType").json()
+
+    def get_portfolio_set_aside(self, portfolio_id, aside_cash_id):
+        """Get a single portfolio set-aside cash entry.
+
+        Args:
+            portfolio_id: Portfolio ID
+            aside_cash_id: Set-aside-cash ID
+
+        Returns:
+            dict: Set-aside entry
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/asideCash/{aside_cash_id}"
+        ).json()
+
+    def list_portfolio_accounts_simple(self, body):
+        """List portfolio accounts (simple) via the v1 POST-body endpoint.
+
+        Args:
+            body: Filter DTO (request body)
+
+        Returns:
+            list: Account dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/accounts/simple/list", requests.post, json=body
+        ).json()
+
+    def get_portfolio_levels(self, body):
+        """Get portfolio levels (POST-body read).
+
+        Args:
+            body: Portfolio-IDs DTO (request body)
+
+        Returns:
+            list | dict: Portfolio levels
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/levels", requests.post, json=body
+        ).json()
+
+    def get_new_portfolio_template(self):
+        """Get a blank/new portfolio template.
+
+        Returns:
+            dict: New-portfolio template
+        """
+        return self.api_request(f"{self.base_url}/portfolio/portfolios/new").json()
+
+    def get_portfolios_by_household(self, household_ids):
+        """Get portfolios for the given household IDs.
+
+        Args:
+            household_ids: Household ID(s) (maps to ``householdIds``)
+
+        Returns:
+            list: Portfolio dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios", params={"householdIds": household_ids}
+        ).json()
+
+    def get_model_detail_portfolio_ids(self):
+        """Get model-detail portfolio IDs.
+
+        Returns:
+            list | dict: Portfolio IDs
+        """
+        return self.api_request(f"{self.base_url}/modeling/models/modelDetails/portfolioId").json()
+
+    def get_model_import_error_logs(self):
+        """Get model-import error logs.
+
+        Returns:
+            list: Error-log dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/modeling/models/upload/modelImportErrorLogs"
+        ).json()
+
+    def upload_model(self, payload):
+        """Upload a model file (mutating).
+
+        Args:
+            payload: Upload DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url}/modeling/models/upload", requests.post, json=payload
+        ).json()
+
+    def validate_model_upload(self, payload):
+        """Validate a model upload (POST-body).
+
+        Args:
+            payload: Upload DTO (request body)
+
+        Returns:
+            dict: Validation result
+        """
+        return self.api_request(
+            f"{self.base_url}/modeling/models/upload/validate", requests.post, json=payload
+        ).json()
+
+    def retry_update_other_model(self, payload):
+        """Retry the update-other-model process (mutating).
+
+        Args:
+            payload: Retry DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url}/modeling/models/updateOtherModel/retryProcess",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def get_security_maintain(self, location):
+        """Get security maintenance data for a location.
+
+        Args:
+            location: Maintenance location
+
+        Returns:
+            list | dict: Maintenance data
+        """
+        return self.api_request(f"{self.base_url}/security/securities/maintain/{location}").json()
+
 
 class EclipseV2(EclipseBase):
     """Eclipse client targeting the v2 API surface (``/api/v2/...``) only.
@@ -9331,6 +9516,435 @@ class EclipseV2(EclipseBase):
             json=payload,
         )
         return res.json()
+
+    # =========================================================================
+    # Coverage batch 15 (v2): deepen Accounts / Portfolios / Models & securities.
+    # =========================================================================
+
+    # --- Accounts ---
+
+    def get_accounts(self, filter_id=None):
+        """Get accounts (v2 list).
+
+        Args:
+            filter_id: Optional filter ID (maps to ``filterId``)
+
+        Returns:
+            list: Account dicts
+        """
+        params = {}
+        if filter_id is not None:
+            params["filterId"] = filter_id
+        return self.api_request(f"{self.base_url_v2}/Account/Accounts", params=params).json()
+
+    def get_account(self, account_id):
+        """Get an account's detail (v2).
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            dict: Account detail
+        """
+        return self.api_request(f"{self.base_url_v2}/Account/Accounts/{account_id}").json()
+
+    def get_restricted_plan_accounts(self, restricted_plan_id=None, external_plan_id=None):
+        """Get the accounts linked to a restricted plan.
+
+        Args:
+            restricted_plan_id: Optional restricted-plan ID (``restrictedPlanId``)
+            external_plan_id: Optional external plan ID (``externalPlanId``)
+
+        Returns:
+            list: Account dicts
+        """
+        params = {}
+        if restricted_plan_id is not None:
+            params["restrictedPlanId"] = restricted_plan_id
+        if external_plan_id is not None:
+            params["externalPlanId"] = external_plan_id
+        return self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/RestrictedPlan", params=params
+        ).json()
+
+    def get_date_account_set_asides(self, condition=None, number_of_days=None):
+        """Get date-based account set-asides over a range.
+
+        Args:
+            condition: Optional condition (maps to ``condition``)
+            number_of_days: Optional day count (maps to ``numberOfDays``)
+
+        Returns:
+            list: Set-aside dicts
+        """
+        params = {}
+        if condition is not None:
+            params["condition"] = condition
+        if number_of_days is not None:
+            params["numberOfDays"] = number_of_days
+        return self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/dateaccountsetasides", params=params
+        ).json()
+
+    def get_expired_set_asides_and_transactions(self, transactions_types=None, number_of_days=None):
+        """Get expired account set-asides and the transactions that expired them.
+
+        Args:
+            transactions_types: Optional transaction types (``transactionsTypes``)
+            number_of_days: Optional day count (``numberOfDays``)
+
+        Returns:
+            list: Set-aside/transaction dicts
+        """
+        params = {}
+        if transactions_types is not None:
+            params["transactionsTypes"] = transactions_types
+        if number_of_days is not None:
+            params["numberOfDays"] = number_of_days
+        return self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/expiredaccountsetasidesandtransactions",
+            params=params,
+        ).json()
+
+    def get_unexpired_set_asides_and_transactions(
+        self, transactions_types=None, number_of_days=None
+    ):
+        """Get unexpired account set-asides that had transactions.
+
+        Args:
+            transactions_types: Optional transaction types (``transactionsTypes``)
+            number_of_days: Optional day count (``numberOfDays``)
+
+        Returns:
+            list: Set-aside/transaction dicts
+        """
+        params = {}
+        if transactions_types is not None:
+            params["transactionsTypes"] = transactions_types
+        if number_of_days is not None:
+            params["numberOfDays"] = number_of_days
+        return self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/unexpiredaccountsetasidesandtransactions",
+            params=params,
+        ).json()
+
+    def get_astro_account_log(self, account_id=None, batch_name=None, connect_firm_id=None):
+        """Get the Astro account optimization log.
+
+        Args:
+            account_id: Optional account ID (``accountId``)
+            batch_name: Optional batch name (``batchName``)
+            connect_firm_id: Optional Orion Connect firm ID (``connectFirmId``)
+
+        Returns:
+            dict | list: Optimization log
+        """
+        params = {}
+        if account_id is not None:
+            params["accountId"] = account_id
+        if batch_name is not None:
+            params["batchName"] = batch_name
+        if connect_firm_id is not None:
+            params["connectFirmId"] = connect_firm_id
+        return self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/Log", params=params
+        ).json()
+
+    def get_astro_account_saved_investor_preferences(self, account_id):
+        """Get the saved Astro investor preferences for an account.
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            dict: Investor preferences
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/preference/{account_id}/InvestorPreferences"
+        ).json()
+
+    def update_astro_fields(self):
+        """Trigger an Astro-fields update (mutating)."""
+        return self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/UpdateAstroFields", requests.post
+        ).json()
+
+    def update_astro_account_investor_preferences(self, account_id, payload, al_client_id=None):
+        """Update Astro investor preferences for an account (mutating).
+
+        Args:
+            account_id: Account ID
+            payload: Investor-preferences DTO (request body)
+            al_client_id: Optional AL client ID (``alClientId``)
+        """
+        params = {}
+        if al_client_id is not None:
+            params["alClientId"] = al_client_id
+        return self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/InvestorPreferences/{account_id}",
+            requests.put,
+            json=payload,
+            params=params,
+        ).json()
+
+    # --- Portfolios ---
+
+    def get_portfolio_v2(self, portfolio_id):
+        """Get portfolio details (v2).
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Portfolio details
+        """
+        return self.api_request(f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}").json()
+
+    def get_portfolio_summary(self, portfolio_id):
+        """Get the portfolio summary (v2 beta).
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            dict: Portfolio summary
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/summary/{portfolio_id}"
+        ).json()
+
+    def get_portfolio_accounts_v2(self, portfolio_id):
+        """Get a portfolio's accounts (v2).
+
+        Args:
+            portfolio_id: Portfolio ID
+
+        Returns:
+            list: Account dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/Accounts"
+        ).json()
+
+    def get_portfolios_by_group(self, portfolio_group_id):
+        """Get portfolios by portfolio-group ID.
+
+        Args:
+            portfolio_group_id: Portfolio-group ID
+
+        Returns:
+            list: Portfolio dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/ByPortfolioGroup/{portfolio_group_id}"
+        ).json()
+
+    def get_portfolio_list(self, filter=None, limit=None, offset=None):
+        """Get the firm portfolio list (v2).
+
+        Args:
+            filter: Optional filter (maps to ``filter``)
+            limit / offset: Optional paging window
+
+        Returns:
+            list: Portfolio dicts
+        """
+        params = {}
+        if filter is not None:
+            params["filter"] = filter
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/GetPortfolioList", params=params
+        ).json()
+
+    def get_portfolio_out_of_tolerance(
+        self, model_id, asset_id, asset_type=None, model_element_id=None
+    ):
+        """Get out-of-tolerance portfolios for a model asset.
+
+        Args:
+            model_id: Model ID
+            asset_id: Asset ID
+            asset_type: Optional asset type (``assetType``)
+            model_element_id: Optional model-element ID (``modelElementId``)
+
+        Returns:
+            list: Out-of-tolerance portfolio dicts
+        """
+        params = {}
+        if asset_type is not None:
+            params["assetType"] = asset_type
+        if model_element_id is not None:
+            params["modelElementId"] = model_element_id
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{model_id}/OutOfTolerance/{asset_id}",
+            params=params,
+        ).json()
+
+    def get_portfolio_allocations_security(self, portfolio_id, assign_by_security=None):
+        """Get portfolio allocations by security.
+
+        Args:
+            portfolio_id: Portfolio ID
+            assign_by_security: Optional bool (``assignBySecurity``)
+
+        Returns:
+            list: Allocation-security dicts
+        """
+        params = {}
+        if assign_by_security is not None:
+            params["assignBySecurity"] = str(assign_by_security).lower()
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/PortfolioAllocationsSecurity",
+            params=params,
+        ).json()
+
+    def get_portfolio_substitutions_history(self, portfolio_id, from_date=None, to_date=None):
+        """Get a portfolio's substitutions history.
+
+        Args:
+            portfolio_id: Portfolio ID
+            from_date / to_date: Optional ISO date window (``fromDate`` / ``toDate``)
+
+        Returns:
+            list: Substitution-history dicts
+        """
+        params = {}
+        if from_date is not None:
+            params["fromDate"] = from_date
+        if to_date is not None:
+            params["toDate"] = to_date
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/PortfolioSubstitutionsHistory",
+            params=params,
+        ).json()
+
+    def get_portfolio_team_history(self, portfolio_id, start_date=None, end_date=None):
+        """Get a portfolio's team history.
+
+        Args:
+            portfolio_id: Portfolio ID
+            start_date / end_date: Optional ISO date window (``startDate`` / ``endDate``)
+
+        Returns:
+            list: Team-history dicts
+        """
+        params = {}
+        if start_date is not None:
+            params["startDate"] = start_date
+        if end_date is not None:
+            params["endDate"] = end_date
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}/TeamHistory", params=params
+        ).json()
+
+    def get_sleeve_strategy_aggregates(self):
+        """Get all sleeve strategy aggregates.
+
+        Returns:
+            list: Sleeve-strategy-aggregate dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Sleeves/SleeveStrategyAggregates"
+        ).json()
+
+    # --- Models & securities (POST-body reads) ---
+
+    def get_assigned_models(self, payload):
+        """Get assigned models (POST-body read).
+
+        Args:
+            payload: Criteria DTO (request body)
+
+        Returns:
+            list: Model dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Modeling/Models/GetAssignedModels", requests.post, json=payload
+        ).json()
+
+    def get_stress_test_results(self, payload):
+        """Get HiddenLevers stress-test results (POST-body read).
+
+        Args:
+            payload: Criteria DTO (request body)
+
+        Returns:
+            dict | list: Stress-test results
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Modeling/Models/StressTestResults", requests.post, json=payload
+        ).json()
+
+    def get_securities_by_name(self, payload):
+        """Get securities by name (async POST-body read).
+
+        Args:
+            payload: Names DTO (request body)
+
+        Returns:
+            list: Security dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Security/GetSecuritiesByNameAsync", requests.post, json=payload
+        ).json()
+
+    def get_securities_by_ticker(self, payload):
+        """Get securities by ticker (async POST-body read).
+
+        Args:
+            payload: Tickers DTO (request body)
+
+        Returns:
+            list: Security dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Security/GetSecuritiesByTickerAsync", requests.post, json=payload
+        ).json()
+
+    def get_securities_by_oc_external_ids(self, payload):
+        """Get securities by Orion Connect external IDs (POST-body read).
+
+        Args:
+            payload: External-IDs DTO (request body)
+
+        Returns:
+            list: Security dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Security/GetSecuritiesByOrionConnectExternalIds",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def get_security_models(self, payload):
+        """Get the models that use given securities (POST-body read).
+
+        Args:
+            payload: Security-IDs DTO (request body)
+
+        Returns:
+            list: Model dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Security/GetSecurityModels", requests.post, json=payload
+        ).json()
+
+    def get_securities_prices(self, payload):
+        """Get prices for securities (POST-body read).
+
+        Args:
+            payload: Security-IDs DTO (request body)
+
+        Returns:
+            list: Price dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Security/SecuritiesPrices", requests.post, json=payload
+        ).json()
 
 
 class Eclipse(EclipseBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.15.0"
+version = "2.16.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3389,3 +3389,227 @@ class TestEclipseV1WritesBatch14:
     def test_delete_security_set(self):
         m = self._c("delete", lambda a: a.delete_security_set(9))
         assert m.call_args.args[0] == f"{V1_BASE}/security/securityset/9"
+
+
+class TestEclipseV2CoverageBatch15:
+    """v2 Accounts/Portfolios/Models&securities deepening (batch 15)."""
+
+    def _g(self, fn):
+        api = _eclipse_for_set_asides()
+        m = _mock_get([])
+        with patch("requests.get", m):
+            fn(api)
+        return m
+
+    def _w(self, verb, fn):
+        api = _eclipse_for_set_asides()
+        m = _mock_post({})
+        with patch(f"requests.{verb}", m):
+            fn(api)
+        return m
+
+    def test_get_accounts(self):
+        m = self._g(lambda a: a.get_accounts(filter_id=2))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/Accounts"
+        assert m.call_args.kwargs["params"] == {"filterId": 2}
+
+    def test_get_account(self):
+        m = self._g(lambda a: a.get_account(57))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/Accounts/57"
+
+    def test_restricted_plan_accounts(self):
+        m = self._g(lambda a: a.get_restricted_plan_accounts(restricted_plan_id=3))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/Accounts/RestrictedPlan"
+        assert m.call_args.kwargs["params"] == {"restrictedPlanId": 3}
+
+    def test_date_account_set_asides(self):
+        m = self._g(lambda a: a.get_date_account_set_asides(number_of_days=30))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/Accounts/dateaccountsetasides"
+
+    def test_expired_set_asides(self):
+        m = self._g(lambda a: a.get_expired_set_asides_and_transactions(number_of_days=30))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Account/Accounts/expiredaccountsetasidesandtransactions"
+        )
+
+    def test_unexpired_set_asides(self):
+        m = self._g(lambda a: a.get_unexpired_set_asides_and_transactions(number_of_days=30))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Account/Accounts/unexpiredaccountsetasidesandtransactions"
+        )
+
+    def test_astro_account_log(self):
+        m = self._g(lambda a: a.get_astro_account_log(account_id=5))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/AstroAccounts/Log"
+
+    def test_astro_saved_investor_prefs(self):
+        m = self._g(lambda a: a.get_astro_account_saved_investor_preferences(5))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Account/AstroAccounts/preference/5/InvestorPreferences"
+        )
+
+    def test_update_astro_fields(self):
+        m = self._w("post", lambda a: a.update_astro_fields())
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/AstroAccounts/UpdateAstroFields"
+
+    def test_update_astro_account_investor_prefs(self):
+        m = self._w("put", lambda a: a.update_astro_account_investor_preferences(5, {"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/AstroAccounts/InvestorPreferences/5"
+
+    def test_portfolio_v2(self):
+        m = self._g(lambda a: a.get_portfolio_v2(7))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7"
+
+    def test_portfolio_summary(self):
+        m = self._g(lambda a: a.get_portfolio_summary(7))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/summary/7"
+
+    def test_portfolio_accounts_v2(self):
+        m = self._g(lambda a: a.get_portfolio_accounts_v2(7))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7/Accounts"
+
+    def test_portfolios_by_group(self):
+        m = self._g(lambda a: a.get_portfolios_by_group(4))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/ByPortfolioGroup/4"
+
+    def test_portfolio_list(self):
+        m = self._g(lambda a: a.get_portfolio_list(limit=5))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/GetPortfolioList"
+        assert m.call_args.kwargs["params"] == {"limit": 5}
+
+    def test_portfolio_out_of_tolerance(self):
+        m = self._g(lambda a: a.get_portfolio_out_of_tolerance(5, 9, asset_type="class"))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/5/OutOfTolerance/9"
+        assert m.call_args.kwargs["params"] == {"assetType": "class"}
+
+    def test_portfolio_allocations_security(self):
+        m = self._g(lambda a: a.get_portfolio_allocations_security(7, assign_by_security=True))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Portfolio/Portfolios/7/PortfolioAllocationsSecurity"
+        )
+        assert m.call_args.kwargs["params"] == {"assignBySecurity": "true"}
+
+    def test_portfolio_substitutions_history(self):
+        m = self._g(lambda a: a.get_portfolio_substitutions_history(7, from_date="2026-01-01"))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Portfolio/Portfolios/7/PortfolioSubstitutionsHistory"
+        )
+
+    def test_portfolio_team_history(self):
+        m = self._g(lambda a: a.get_portfolio_team_history(7))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7/TeamHistory"
+
+    def test_sleeve_strategy_aggregates(self):
+        m = self._g(lambda a: a.get_sleeve_strategy_aggregates())
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Sleeves/SleeveStrategyAggregates"
+
+    def test_assigned_models(self):
+        m = self._w("post", lambda a: a.get_assigned_models({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Modeling/Models/GetAssignedModels"
+
+    def test_stress_test_results(self):
+        m = self._w("post", lambda a: a.get_stress_test_results({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Modeling/Models/StressTestResults"
+
+    def test_securities_by_name(self):
+        m = self._w("post", lambda a: a.get_securities_by_name(["Apple"]))
+        assert m.call_args.args[0] == f"{V2_BASE}/Security/GetSecuritiesByNameAsync"
+
+    def test_securities_by_ticker(self):
+        m = self._w("post", lambda a: a.get_securities_by_ticker(["AAPL"]))
+        assert m.call_args.args[0] == f"{V2_BASE}/Security/GetSecuritiesByTickerAsync"
+
+    def test_securities_by_oc_external_ids(self):
+        m = self._w("post", lambda a: a.get_securities_by_oc_external_ids(["x"]))
+        assert m.call_args.args[0] == (f"{V2_BASE}/Security/GetSecuritiesByOrionConnectExternalIds")
+
+    def test_security_models(self):
+        m = self._w("post", lambda a: a.get_security_models([1]))
+        assert m.call_args.args[0] == f"{V2_BASE}/Security/GetSecurityModels"
+
+    def test_securities_prices(self):
+        m = self._w("post", lambda a: a.get_securities_prices([1]))
+        assert m.call_args.args[0] == f"{V2_BASE}/Security/SecuritiesPrices"
+
+
+class TestEclipseV1CoverageBatch15:
+    """v1 Accounts/Portfolios/Models&sec-sets deepening (batch 15)."""
+
+    def _g(self, fn):
+        api = _eclipse_v1()
+        m = _mock_get([])
+        with patch("requests.get", m):
+            fn(api)
+        return m
+
+    def _w(self, verb, fn):
+        api = _eclipse_v1()
+        m = _mock_post({})
+        with patch(f"requests.{verb}", m):
+            fn(api)
+        return m
+
+    def test_house_account(self):
+        m = self._g(lambda a: a.get_house_account(3))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/action/houseAccount/3"
+
+    def test_new_account_template(self):
+        m = self._g(lambda a: a.get_new_account_template())
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/new"
+
+    def test_account_set_aside(self):
+        m = self._g(lambda a: a.get_account_set_aside(5, 3))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/asidecash/3"
+
+    def test_accounts_portfolio_ids_detail(self):
+        m = self._w("post", lambda a: a.get_accounts_portfolio_ids_detail([1]))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/list/portfolioIdsDetail"
+
+    def test_aside_cash_account_types(self):
+        m = self._g(lambda a: a.get_aside_cash_account_types())
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/asideCashAccountType"
+
+    def test_portfolio_set_aside(self):
+        m = self._g(lambda a: a.get_portfolio_set_aside(7, 3))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/asideCash/3"
+
+    def test_list_portfolio_accounts_simple(self):
+        m = self._w("post", lambda a: a.list_portfolio_accounts_simple({"f": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/accounts/simple/list"
+
+    def test_portfolio_levels(self):
+        m = self._w("post", lambda a: a.get_portfolio_levels([1]))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/levels"
+
+    def test_new_portfolio_template(self):
+        m = self._g(lambda a: a.get_new_portfolio_template())
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/new"
+
+    def test_portfolios_by_household(self):
+        m = self._g(lambda a: a.get_portfolios_by_household(99))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios"
+        assert m.call_args.kwargs["params"] == {"householdIds": 99}
+
+    def test_model_detail_portfolio_ids(self):
+        m = self._g(lambda a: a.get_model_detail_portfolio_ids())
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/modelDetails/portfolioId"
+
+    def test_model_import_error_logs(self):
+        m = self._g(lambda a: a.get_model_import_error_logs())
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/upload/modelImportErrorLogs"
+
+    def test_upload_model(self):
+        m = self._w("post", lambda a: a.upload_model({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/upload"
+
+    def test_validate_model_upload(self):
+        m = self._w("post", lambda a: a.validate_model_upload({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/upload/validate"
+
+    def test_retry_update_other_model(self):
+        m = self._w("post", lambda a: a.retry_update_other_model({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/updateOtherModel/retryProcess"
+
+    def test_security_maintain(self):
+        m = self._g(lambda a: a.get_security_maintain("NY"))
+        assert m.call_args.args[0] == f"{V1_BASE}/security/securities/maintain/NY"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1479,3 +1479,53 @@ class TestEclipseV1ReadCoverageBatch13:
         if not models:
             pytest.skip("No models available")
         assert isinstance(eclipse_client.v1.get_model_security_types(models[0]["id"]), (list, dict))
+
+
+class TestEclipseCoverageBatch15:
+    """Live smoke tests for batch-15 account/portfolio/model/security reads."""
+
+    def _pid(self, c):
+        ps = c.v1.get_all_portfolios(top=1)
+        if not ps:
+            pytest.skip("no portfolios")
+        return ps[0]["id"]
+
+    def test_v2_get_accounts(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_accounts(), list)
+
+    def test_v2_get_account(self, eclipse_client):
+        accts = eclipse_client.v1.get_all_accounts()
+        if not accts:
+            pytest.skip("no accounts")
+        assert isinstance(eclipse_client.v2.get_account(accts[0]["id"]), dict)
+
+    def test_v2_portfolio_v2(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_portfolio_v2(self._pid(eclipse_client)), dict)
+
+    def test_v2_portfolio_summary(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_portfolio_summary(self._pid(eclipse_client)), dict)
+
+    def test_v2_portfolio_accounts_v2(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_portfolio_accounts_v2(self._pid(eclipse_client)), list
+        )
+
+    def test_v2_portfolio_team_history(self, eclipse_client):
+        assert isinstance(
+            eclipse_client.v2.get_portfolio_team_history(self._pid(eclipse_client)), list
+        )
+
+    def test_v2_portfolio_list(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_portfolio_list(limit=3), list)
+
+    def test_v2_securities_by_ticker(self, eclipse_client):
+        assert isinstance(eclipse_client.v2.get_securities_by_ticker(["AAPL"]), list)
+
+    def test_v1_aside_cash_account_types(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_aside_cash_account_types(), list)
+
+    def test_v1_model_detail_portfolio_ids(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_model_detail_portfolio_ids(), (list, dict))
+
+    def test_v1_new_account_template(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_new_account_template(), (list, dict))


### PR DESCRIPTION
43 methods (27 v2 + 16 v1) deepening the Accounts, Portfolios, and Models/Security-Sets categories across both surfaces (no trade execution/approval). Live-verified reads; sleeve strategy aggregates role-gated (SLEEVES), mutating endpoints unit-tested only. 452 unit + 11 live pass; ruff clean. Version 2.15.0 -> 2.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)