### PR TITLE
Eclipse coverage batch 16: sweep remaining Accounts/Portfolios/Models gaps (2.17.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.16.0"
+__version__ = "2.17.0"
 
 import logging
 import re
@@ -5675,6 +5675,122 @@ class EclipseV1(EclipseBase):
         """
         return self.api_request(f"{self.base_url}/security/securities/maintain/{location}").json()
 
+    # --- Coverage batch 16 sweep (v1 account/portfolio/model/security remainder) ---
+
+    def get_account_portfolio_id_by_firm(self, account_id, firm_id):
+        """Get the portfolio ID for an account scoped by firm.
+
+        Args:
+            account_id: Account ID
+            firm_id: Firm ID
+
+        Returns:
+            dict | int: Portfolio ID
+        """
+        return self.api_request(
+            f"{self.base_url}/account/accounts/{account_id}/{firm_id}/portfolioId"
+        ).json()
+
+    def get_security_count(self, security_id, body=None):
+        """Get a usage count for a security (POST-body).
+
+        Args:
+            security_id: Security ID
+            body: Optional criteria DTO (request body)
+
+        Returns:
+            dict | int: Count
+        """
+        return self.api_request(
+            f"{self.base_url}/security/securities/{security_id}/count", requests.post, json=body
+        ).json()
+
+    def create_portfolio_aside_cash(self, portfolio_id, payload):
+        """Create set-aside cash for a portfolio (mutating).
+
+        Args:
+            portfolio_id: Portfolio ID
+            payload: Set-aside DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/asideCash",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def get_sleeve_allocations_v1(self, account_id):
+        """Get sleeve allocation details for an account (v1).
+
+        Args:
+            account_id: Account ID
+
+        Returns:
+            list | dict: Sleeve allocations
+        """
+        return self.api_request(
+            f"{self.base_url}/portfolio/sleeves/{account_id}/allocations"
+        ).json()
+
+    def get_model_tolerance_detail(
+        self, portfolio_id, account_id, asset_type=None, is_sleeved_portfolio=None
+    ):
+        """Get model tolerance detail for a portfolio/account by asset type.
+
+        Args:
+            portfolio_id: Portfolio ID
+            account_id: Account ID
+            asset_type: Optional asset type (``assetType``)
+            is_sleeved_portfolio: Optional flag (``isSleevedPortfolio``)
+
+        Returns:
+            dict | list: Model tolerance detail
+        """
+        params = {}
+        if asset_type is not None:
+            params["assetType"] = asset_type
+        if is_sleeved_portfolio is not None:
+            params["isSleevedPortfolio"] = is_sleeved_portfolio
+        return self.api_request(
+            f"{self.base_url}/portfolio/portfolios/{portfolio_id}/modelTolerance/{account_id}",
+            params=params,
+        ).json()
+
+    def delete_submodel(self, submodel_id, model_id=None, model_detail_id=None):
+        """Delete a submodel (mutating).
+
+        Args:
+            submodel_id: Submodel ID
+            model_id: Optional model ID (maps to ``modelId``)
+            model_detail_id: Optional model-detail ID (maps to ``modelDetailId``)
+        """
+        params = {}
+        if model_id is not None:
+            params["modelId"] = model_id
+        if model_detail_id is not None:
+            params["modelDetailId"] = model_detail_id
+        return self.api_request(
+            f"{self.base_url}/modeling/models/submodels/{submodel_id}",
+            requests.delete,
+            params=params,
+        ).json()
+
+    def update_submodel_by_model(self, payload, model_id=None):
+        """Update a submodel in the context of a model (mutating).
+
+        Args:
+            payload: Submodel DTO (request body)
+            model_id: Optional model ID (maps to ``modelId``)
+        """
+        params = {}
+        if model_id is not None:
+            params["modelId"] = model_id
+        return self.api_request(
+            f"{self.base_url}/modeling/models/submodels",
+            requests.put,
+            json=payload,
+            params=params,
+        ).json()
+
 
 class EclipseV2(EclipseBase):
     """Eclipse client targeting the v2 API surface (``/api/v2/...``) only.
@@ -9944,6 +10060,89 @@ class EclipseV2(EclipseBase):
         """
         return self.api_request(
             f"{self.base_url_v2}/Security/SecuritiesPrices", requests.post, json=payload
+        ).json()
+
+    # --- Coverage batch 16 sweep (v2 account/portfolio remainder) ---
+
+    def set_accounts_do_not_trade_all_reverse_sync(self, payload):
+        """Reverse-sync the do-not-trade flag for all accounts (mutating).
+
+        Args:
+            payload: DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/donottradeallaccountsreversesync",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def get_account_excluded_cash_details(self, account_portfolio_id, id_type):
+        """Get model-tolerance excluded-cash details for an account.
+
+        Args:
+            account_portfolio_id: Account or portfolio ID
+            id_type: ID type (e.g. account vs portfolio)
+
+        Returns:
+            dict: Excluded-cash details
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Account/Accounts/{account_portfolio_id}/{id_type}"
+            f"/modelTolerance/AccountExcludedCashDetails"
+        ).json()
+
+    def get_astro_account_message(self, account_id, batch_name, connect_firm_id=None):
+        """Get the Astro optimization message for an account/batch.
+
+        Args:
+            account_id: Account ID
+            batch_name: Batch name
+            connect_firm_id: Optional Orion Connect firm ID (``connectFirmId``)
+
+        Returns:
+            dict: Optimization message
+        """
+        params = {}
+        if connect_firm_id is not None:
+            params["connectFirmId"] = connect_firm_id
+        return self.api_request(
+            f"{self.base_url_v2}/Account/AstroAccounts/Message/Account/{account_id}"
+            f"/Batch/{batch_name}",
+            params=params,
+        ).json()
+
+    def export_portfolios_grid(self):
+        """Export the portfolios list as Excel grid data (mutating/export)."""
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/list/export/excel/griddata", requests.post
+        ).json()
+
+    def patch_portfolio(self, portfolio_id, payload):
+        """Patch a portfolio (partial update, mutating).
+
+        Args:
+            portfolio_id: Portfolio ID
+            payload: Partial portfolio DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Portfolios/{portfolio_id}",
+            requests.patch,
+            json=payload,
+        ).json()
+
+    def get_sleeve_strategy_aggregates_by_firm_ids(self, payload):
+        """Get sleeve strategy aggregates for a list of firm IDs (POST-body read).
+
+        Args:
+            payload: List of firm IDs (request body)
+
+        Returns:
+            list: Sleeve-strategy-aggregate dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Portfolio/Sleeves/SleeveStrategyAggregatesByFirmIds",
+            requests.post,
+            json=payload,
         ).json()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.16.0"
+version = "2.17.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3613,3 +3613,83 @@ class TestEclipseV1CoverageBatch15:
     def test_security_maintain(self):
         m = self._g(lambda a: a.get_security_maintain("NY"))
         assert m.call_args.args[0] == f"{V1_BASE}/security/securities/maintain/NY"
+
+
+class TestEclipseCoverageBatch16Sweep:
+    """Sweep of remaining focus-category endpoints (batch 16)."""
+
+    def _v2(self, verb, fn):
+        api = _eclipse_for_set_asides()
+        m = _mock_get([]) if verb == "get" else _mock_post({})
+        with patch(f"requests.{verb}", m):
+            fn(api)
+        return m
+
+    def _v1(self, verb, fn):
+        api = _eclipse_v1()
+        m = _mock_get([]) if verb == "get" else _mock_post({})
+        with patch(f"requests.{verb}", m):
+            fn(api)
+        return m
+
+    # v2
+    def test_do_not_trade_all_reverse_sync(self):
+        m = self._v2("post", lambda a: a.set_accounts_do_not_trade_all_reverse_sync({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/Accounts/donottradeallaccountsreversesync"
+
+    def test_account_excluded_cash_details(self):
+        m = self._v2("get", lambda a: a.get_account_excluded_cash_details(5, "account"))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Account/Accounts/5/account/modelTolerance/AccountExcludedCashDetails"
+        )
+
+    def test_astro_account_message(self):
+        m = self._v2("get", lambda a: a.get_astro_account_message(5, "b1"))
+        assert m.call_args.args[0] == f"{V2_BASE}/Account/AstroAccounts/Message/Account/5/Batch/b1"
+
+    def test_export_portfolios_grid(self):
+        m = self._v2("post", lambda a: a.export_portfolios_grid())
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/list/export/excel/griddata"
+
+    def test_patch_portfolio(self):
+        m = self._v2("patch", lambda a: a.patch_portfolio(7, {"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Portfolio/Portfolios/7"
+        assert m.call_args.kwargs["json"] == {"x": 1}
+
+    def test_sleeve_strategy_aggregates_by_firm_ids(self):
+        m = self._v2("post", lambda a: a.get_sleeve_strategy_aggregates_by_firm_ids([1]))
+        assert (
+            m.call_args.args[0] == f"{V2_BASE}/Portfolio/Sleeves/SleeveStrategyAggregatesByFirmIds"
+        )
+
+    # v1
+    def test_account_portfolio_id_by_firm(self):
+        m = self._v1("get", lambda a: a.get_account_portfolio_id_by_firm(5, 9))
+        assert m.call_args.args[0] == f"{V1_BASE}/account/accounts/5/9/portfolioId"
+
+    def test_security_count(self):
+        m = self._v1("post", lambda a: a.get_security_count(42, {"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/security/securities/42/count"
+
+    def test_create_portfolio_aside_cash(self):
+        m = self._v1("post", lambda a: a.create_portfolio_aside_cash(7, {"amount": 100}))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/asideCash"
+
+    def test_sleeve_allocations_v1(self):
+        m = self._v1("get", lambda a: a.get_sleeve_allocations_v1(5))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/sleeves/5/allocations"
+
+    def test_model_tolerance_detail(self):
+        m = self._v1("get", lambda a: a.get_model_tolerance_detail(7, 5, asset_type="class"))
+        assert m.call_args.args[0] == f"{V1_BASE}/portfolio/portfolios/7/modelTolerance/5"
+        assert m.call_args.kwargs["params"] == {"assetType": "class"}
+
+    def test_delete_submodel(self):
+        m = self._v1("delete", lambda a: a.delete_submodel(8, model_id=5, model_detail_id=3))
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/submodels/8"
+        assert m.call_args.kwargs["params"] == {"modelId": 5, "modelDetailId": 3}
+
+    def test_update_submodel_by_model(self):
+        m = self._v1("put", lambda a: a.update_submodel_by_model({"x": 1}, model_id=5))
+        assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/submodels"
+        assert m.call_args.kwargs["params"] == {"modelId": 5}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1529,3 +1529,19 @@ class TestEclipseCoverageBatch15:
 
     def test_v1_new_account_template(self, eclipse_client):
         assert isinstance(eclipse_client.v1.get_new_account_template(), (list, dict))
+
+
+class TestEclipseCoverageBatch16Sweep:
+    """Live smoke for the verifiable batch-16 sweep read.
+
+    Sleeve allocations are role-gated (SLEEVES); model-tolerance-detail needs
+    isSleevedPortfolio; excluded-cash needs a valid id_type — so those plus all
+    writes are unit-tested only.
+    """
+
+    def test_account_portfolio_id_by_firm(self, eclipse_client):
+        accts = eclipse_client.v1.get_all_accounts()
+        if not accts:
+            pytest.skip("no accounts")
+        result = eclipse_client.v1.get_account_portfolio_id_by_firm(accts[0]["id"], 1)
+        assert isinstance(result, (list, dict, int))


### PR DESCRIPTION
Sweeps the non-excluded remaining endpoints in the focus categories (13 methods: 6 v2 + 7 v1), including a PATCH portfolio and v1 submodel delete/update-by-model. Model-assignment approve/reject (:actionStatus) routes remain excluded per the no-trade-approval scope. Mutating/parameterized endpoints unit-tested only; account_portfolio_id_by_firm live-verified. 465 unit + 1 live pass; ruff clean. Version 2.16.0 -> 2.17.0.

Note: corrected a coverage-measurement artifact (multi-line f-string URLs were undercounted) — accurate combined coverage is ~58-59%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)