### PR TITLE
Eclipse coverage batch 17: complete TradeTool + Admin + Analytics (2.18.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.17.0"
+__version__ = "2.18.0"
 
 import logging
 import re
@@ -5791,6 +5791,391 @@ class EclipseV1(EclipseBase):
             params=params,
         ).json()
 
+    # =========================================================================
+    # Coverage batch 17 (v1): TradeTool (reference + generate/TLH) + Admin token.
+    # Trade-generation endpoints stage trades; pass isViewOnly in the body for
+    # preview. Mutating endpoints unit-tested only.
+    # =========================================================================
+
+    # --- TradeTool reference reads (v1) ---
+
+    def get_trade_priority_rankings(self):
+        """Get the available trade priority rankings.
+
+        Returns:
+            list: Priority-ranking dicts
+        """
+        return self.api_request(f"{self.base_url}/tradetool/priorityrankings").json()
+
+    def get_tactical_rebalance_cash_protection(self):
+        """Get the tactical-rebalance cash-protection options.
+
+        Returns:
+            list | dict: Cash-protection options
+        """
+        return self.api_request(f"{self.base_url}/tradetool/tacticalRebalanceCashProtection").json()
+
+    def get_allow_wash_sales_options(self):
+        """Get the allow-wash-sales options.
+
+        Returns:
+            list: Option dicts
+        """
+        return self.api_request(f"{self.base_url}/tradetool/allowwashsales").json()
+
+    def get_allow_short_term_gains_options(self):
+        """Get the allow-short-term-gains options.
+
+        Returns:
+            list: Option dicts
+        """
+        return self.api_request(f"{self.base_url}/tradetool/allowshorttermgains").json()
+
+    def get_trade_side_options(self):
+        """Get the trade-side options.
+
+        Returns:
+            list: Option dicts
+        """
+        return self.api_request(f"{self.base_url}/tradetool/tradeside").json()
+
+    def get_tlh_gainloss_options(self):
+        """Get the tax-loss-harvesting gain/loss options.
+
+        Returns:
+            list: Option dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/gainloss/options"
+        ).json()
+
+    def get_tlh_sign_options(self):
+        """Get the tax-loss-harvesting sign options.
+
+        Returns:
+            list: Option dicts
+        """
+        return self.api_request(f"{self.base_url}/tradetool/taxLossHarvesting/sign/options").json()
+
+    def get_tlh_term_options(self):
+        """Get the tax-loss-harvesting term options.
+
+        Returns:
+            list: Option dicts
+        """
+        return self.api_request(f"{self.base_url}/tradetool/taxLossHarvesting/term/options").json()
+
+    # --- TradeTool generate / action (v1; pass isViewOnly in body for preview) ---
+
+    def generate_trade_instance(self, payload):
+        """Generate a trade instance.
+
+        Args:
+            payload: Generate DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated instance
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/tradeInstance/action/generateinstance",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def generate_prorated_cash_trade(self, payload):
+        """Generate a prorated-cash trade.
+
+        Args:
+            payload: Generate DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/proratedcash/action/generatetrade",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def generate_raise_cash_trade(self, payload):
+        """Generate a raise-cash trade.
+
+        Args:
+            payload: Generate DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/raisecash/action/generatetrade",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def auto_rebalance(self, payload):
+        """Generate an auto-rebalance trade.
+
+        Args:
+            payload: Auto-rebalance DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/rebalancer/action/autoRebalance",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def generate_global_trade(self, payload):
+        """Generate a global trade.
+
+        Args:
+            payload: Generate DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/globaltrades/action/generateTrade",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def deserialize_global_trade(self, payload):
+        """Deserialize a global-trade upload (POST-body).
+
+        Args:
+            payload: Serialized DTO (request body)
+
+        Returns:
+            dict: Deserialized trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/globaltrades/action/deserialize",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def generate_liquidate_trade(self, payload):
+        """Generate a liquidation trade.
+
+        Args:
+            payload: Liquidate DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/liquidate/generateTrade", requests.post, json=payload
+        ).json()
+
+    def deserialize_ticker_swap(self, payload):
+        """Deserialize a ticker-swap upload (POST-body).
+
+        Args:
+            payload: Serialized DTO (request body)
+
+        Returns:
+            dict: Deserialized data
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/tickerswap/action/deserialize",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def generate_trade_to_target(self, payload):
+        """Generate a trade-to-target trade.
+
+        Args:
+            payload: Trade-to-target DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/tradetotarget/action/generateTrade",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def deserialize_trade_to_target(self, payload):
+        """Deserialize a trade-to-target upload (POST-body).
+
+        Args:
+            payload: Serialized DTO (request body)
+
+        Returns:
+            dict: Deserialized data
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/tradetotarget/action/deserialize",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def upload_trade_file(self, payload, is_sleeve=None):
+        """Upload a trade file.
+
+        Args:
+            payload: Upload DTO (request body)
+            is_sleeve: Optional bool (maps to ``isSleeve``)
+        """
+        params = {}
+        if is_sleeve is not None:
+            params["isSleeve"] = str(is_sleeve).lower()
+        return self.api_request(
+            f"{self.base_url}/tradetool/uploadfile", requests.post, json=payload, params=params
+        ).json()
+
+    # --- TradeTool TLH suite (v1) ---
+
+    def create_tlh_trade(self, payload):
+        """Create a tax-loss-harvesting trade.
+
+        Args:
+            payload: TLH DTO (request body; set isViewOnly for preview)
+
+        Returns:
+            dict: Created trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/createTLHTrade",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def create_tlh_trade_batch(self, payload):
+        """Create a tax-loss-harvesting trade by batch ID.
+
+        Args:
+            payload: TLH batch DTO (request body)
+
+        Returns:
+            dict: Created trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/createTLHTradeBatchId",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def create_tlh_trade_generic(self, payload):
+        """Create a tax-loss-harvesting trade (generic createTrade).
+
+        Args:
+            payload: TLH DTO (request body)
+
+        Returns:
+            dict: Created trade
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/createTrade",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def search_tlh_securities(self, payload):
+        """Search tax-loss-harvesting securities (POST-body).
+
+        Args:
+            payload: Search DTO (request body)
+
+        Returns:
+            list: Security dicts
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/searchTLHsecurity",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def validate_tlh_securities(self, payload):
+        """Validate tax-loss-harvesting securities (POST-body).
+
+        Args:
+            payload: Validation DTO (request body)
+
+        Returns:
+            dict: Validation result
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/validateTLHSecurities",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def validate_buy_preferred_tlh_securities(self, payload):
+        """Validate buy-preferred tax-loss-harvesting securities (POST-body).
+
+        Args:
+            payload: Validation DTO (request body)
+
+        Returns:
+            dict: Validation result
+        """
+        return self.api_request(
+            f"{self.base_url}/tradetool/taxLossHarvesting/action/validateBuyPreferredTHSecurities",
+            requests.post,
+            json=payload,
+        ).json()
+
+    # --- Admin token (v1) ---
+
+    def get_firm_token(self, payload):
+        """Get a firm token (mutating; token issuance).
+
+        Args:
+            payload: Firm DTO (request body)
+
+        Returns:
+            dict: Token
+        """
+        return self.api_request(
+            f"{self.base_url}/admin/token/firm", requests.post, json=payload
+        ).json()
+
+    def get_firm_token_by_id(self, firm_id):
+        """Get a firm token by firm ID.
+
+        Args:
+            firm_id: Firm ID
+
+        Returns:
+            dict: Token
+        """
+        return self.api_request(f"{self.base_url}/admin/token/firm/{firm_id}").json()
+
+    def login_as(self, payload):
+        """Impersonate (login as) another user (mutating).
+
+        Args:
+            payload: Login-as DTO (request body)
+
+        Returns:
+            dict: Token / session
+        """
+        return self.api_request(
+            f"{self.base_url}/admin/token/loginas", requests.post, json=payload
+        ).json()
+
+    def revert_login_as(self):
+        """Revert a login-as impersonation.
+
+        Returns:
+            dict: Token / session
+        """
+        return self.api_request(f"{self.base_url}/admin/token/loginas/revert").json()
+
+    def logout(self):
+        """Log out the current session.
+
+        Returns:
+            dict: Logout result
+        """
+        return self.api_request(f"{self.base_url}/admin/logout").json()
+
 
 class EclipseV2(EclipseBase):
     """Eclipse client targeting the v2 API surface (``/api/v2/...``) only.
@@ -10143,6 +10528,264 @@ class EclipseV2(EclipseBase):
             f"{self.base_url_v2}/Portfolio/Sleeves/SleeveStrategyAggregatesByFirmIds",
             requests.post,
             json=payload,
+        ).json()
+
+    # =========================================================================
+    # Coverage batch 17 (v2): TradeTool, Admin (custodian/execution), Analytics.
+    # Trade-generation endpoints stage/preview trades; pass isViewOnly in the
+    # body for preview. Mutating endpoints unit-tested only.
+    # =========================================================================
+
+    # --- TradeTool (v2) ---
+
+    def get_calculate_contributions_for_sleeves(self):
+        """Calculate contributions for sleeves.
+
+        Returns:
+            dict | list: Contribution calculations
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/TradeTool/CalculateContributionsForSleeves"
+        ).json()
+
+    def raise_cash_by_fund(self, payload):
+        """Generate a raise-cash-by-fund trade (pass isViewOnly in body for preview).
+
+        Args:
+            payload: Raise-cash DTO (request body)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/TradeTool/RaiseCashByFund", requests.post, json=payload
+        ).json()
+
+    def raise_cash_distribution_full_rebalance(self, payload):
+        """Generate a raise-cash-distribution full-rebalance trade.
+
+        Args:
+            payload: Rebalance DTO (request body; pass isViewOnly for preview)
+
+        Returns:
+            dict: Generated trade
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/TradeTool/RaiseCashDistributionFullRebalance",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def get_tlh_opportunity_flag(self, payload):
+        """Get the tax-loss-harvesting opportunity flag (POST-body read).
+
+        Args:
+            payload: Criteria DTO (request body)
+
+        Returns:
+            dict: TLH opportunity flag(s)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/TradeTool/TlhOpportunityFlag", requests.post, json=payload
+        ).json()
+
+    # --- Admin: custodian + execution (v2) ---
+
+    def create_custodian(self, payload):
+        """Create a custodian (mutating).
+
+        Args:
+            payload: Custodian DTO (request body)
+
+        Returns:
+            dict: Created custodian
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian", requests.post, json=payload
+        ).json()
+
+    def get_custodian_algo_tag_info(self, tag_info_id):
+        """Get custodian algo tag info by ID.
+
+        Args:
+            tag_info_id: Algo-tag-info ID
+
+        Returns:
+            dict: Algo tag info
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/CustodianAlgoTagInfo/{tag_info_id}"
+        ).json()
+
+    def get_custodian_algo_tag_info_by_custodian(self, custodian_id):
+        """Get custodian algo tag info for a custodian.
+
+        Args:
+            custodian_id: Custodian ID
+
+        Returns:
+            list: Algo-tag-info dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/CustodianAlgoTagInfoByCustodian/{custodian_id}"
+        ).json()
+
+    def get_custodian_algo_tag_info_by_ids(self, payload):
+        """Get custodian algo tag info for a list of IDs (POST-body read).
+
+        Args:
+            payload: List of IDs (request body)
+
+        Returns:
+            list: Algo-tag-info dicts
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/GetCustodianAlgoTagInfoByIds",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def create_custodian_algo_instructions(self, custodian_id, payload):
+        """Create custodian algo instructions (mutating).
+
+        Args:
+            custodian_id: Custodian ID
+            payload: Algo-instructions DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/{custodian_id}/CustodianAlgoInstructions",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def get_custodian_algo_instruction(self, custodian_id, tag_info_id):
+        """Get a custodian algo instruction by tag-info ID.
+
+        Args:
+            custodian_id: Custodian ID
+            tag_info_id: Algo-tag-info ID
+
+        Returns:
+            dict: Algo instruction
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/{custodian_id}"
+            f"/CustodianAlgoInstructions/{tag_info_id}"
+        ).json()
+
+    def update_custodian_algo_instructions(self, custodian_id, instruction_id, payload):
+        """Update custodian algo instructions (mutating).
+
+        Args:
+            custodian_id: Custodian ID
+            instruction_id: Instruction ID
+            payload: Algo-instructions DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/{custodian_id}"
+            f"/CustodianAlgoInstructions/{instruction_id}",
+            requests.put,
+            json=payload,
+        ).json()
+
+    def delete_custodian_algo_instructions(self, custodian_id, instruction_id):
+        """Delete custodian algo instructions (mutating).
+
+        Args:
+            custodian_id: Custodian ID
+            instruction_id: Instruction ID
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/Custodian/{custodian_id}"
+            f"/CustodianAlgoInstructions/{instruction_id}",
+            requests.delete,
+        ).json()
+
+    def get_trade_execution_sftp_config(self, trade_execution_type_id):
+        """Get the SFTP config for a trade-execution type.
+
+        Args:
+            trade_execution_type_id: Trade-execution-type ID
+
+        Returns:
+            dict: SFTP config
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/tradeExecutionTypes/{trade_execution_type_id}/sftpConfig"
+        ).json()
+
+    def update_trade_execution_sftp_config(self, trade_execution_type_id, payload):
+        """Update the SFTP config for a trade-execution type (mutating).
+
+        Args:
+            trade_execution_type_id: Trade-execution-type ID
+            payload: SFTP-config DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Admin/tradeExecutionTypes/{trade_execution_type_id}/sftpConfig",
+            requests.put,
+            json=payload,
+        ).json()
+
+    # --- Analytics (v2) ---
+
+    def cancel_analytics(self):
+        """Cancel the running analytics (mutating)."""
+        return self.api_request(f"{self.base_url_v2}/Analytics/Cancel", requests.post).json()
+
+    def get_portfolios_analytics_status(self, payload):
+        """Get analytics status for a set of portfolios (POST-body read).
+
+        Args:
+            payload: Portfolio-IDs DTO (request body)
+
+        Returns:
+            dict | list: Analytics status
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Analytics/GetPortfoliosAnalyticsStatus",
+            requests.post,
+            json=payload,
+        ).json()
+
+    def reset_analytics_run_history(self):
+        """Reset the analytics run history (mutating)."""
+        return self.api_request(f"{self.base_url_v2}/Analytics/ResetAnalyticsRunHistory").json()
+
+    def run_analytics_v2(self, payload):
+        """Run analytics (v2, mutating).
+
+        Args:
+            payload: Run-analytics DTO (request body)
+
+        Returns:
+            dict: Run result
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Analytics/RunAnalytics", requests.post, json=payload
+        ).json()
+
+    def update_run_analytics_config(self, config_id, payload):
+        """Update a run-analytics configuration (mutating).
+
+        Args:
+            config_id: Configuration ID
+            payload: Config DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Analytics/RunAnalyticsConfig/{config_id}",
+            requests.put,
+            json=payload,
+        ).json()
+
+    def update_analytics_status(self, payload):
+        """Update the analytics status (mutating).
+
+        Args:
+            payload: Status DTO (request body)
+        """
+        return self.api_request(
+            f"{self.base_url_v2}/Analytics/StatusUpdate", requests.post, json=payload
         ).json()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.17.0"
+version = "2.18.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3693,3 +3693,238 @@ class TestEclipseCoverageBatch16Sweep:
         m = self._v1("put", lambda a: a.update_submodel_by_model({"x": 1}, model_id=5))
         assert m.call_args.args[0] == f"{V1_BASE}/modeling/models/submodels"
         assert m.call_args.kwargs["params"] == {"modelId": 5}
+
+
+class TestEclipseV2TradeToolAdminAnalyticsBatch17:
+    """v2 TradeTool/Admin/Analytics (batch 17)."""
+
+    def _v2(self, verb, fn):
+        api = _eclipse_for_set_asides()
+        m = _mock_get([]) if verb == "get" else _mock_post({})
+        with patch(f"requests.{verb}", m):
+            fn(api)
+        return m
+
+    def test_calc_contributions_for_sleeves(self):
+        m = self._v2("get", lambda a: a.get_calculate_contributions_for_sleeves())
+        assert m.call_args.args[0] == f"{V2_BASE}/TradeTool/CalculateContributionsForSleeves"
+
+    def test_raise_cash_by_fund(self):
+        m = self._v2("post", lambda a: a.raise_cash_by_fund({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/TradeTool/RaiseCashByFund"
+
+    def test_raise_cash_distribution_full_rebalance(self):
+        m = self._v2("post", lambda a: a.raise_cash_distribution_full_rebalance({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/TradeTool/RaiseCashDistributionFullRebalance"
+
+    def test_tlh_opportunity_flag(self):
+        m = self._v2("post", lambda a: a.get_tlh_opportunity_flag({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/TradeTool/TlhOpportunityFlag"
+
+    def test_create_custodian(self):
+        m = self._v2("post", lambda a: a.create_custodian({"name": "C"}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian"
+
+    def test_custodian_algo_tag_info(self):
+        m = self._v2("get", lambda a: a.get_custodian_algo_tag_info(3))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian/CustodianAlgoTagInfo/3"
+
+    def test_custodian_algo_tag_info_by_custodian(self):
+        m = self._v2("get", lambda a: a.get_custodian_algo_tag_info_by_custodian(5))
+        assert m.call_args.args[0] == (
+            f"{V2_BASE}/Admin/Custodian/CustodianAlgoTagInfoByCustodian/5"
+        )
+
+    def test_custodian_algo_tag_info_by_ids(self):
+        m = self._v2("post", lambda a: a.get_custodian_algo_tag_info_by_ids([1]))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian/GetCustodianAlgoTagInfoByIds"
+
+    def test_create_custodian_algo_instructions(self):
+        m = self._v2("post", lambda a: a.create_custodian_algo_instructions(5, {"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian/5/CustodianAlgoInstructions"
+
+    def test_get_custodian_algo_instruction(self):
+        m = self._v2("get", lambda a: a.get_custodian_algo_instruction(5, 9))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian/5/CustodianAlgoInstructions/9"
+
+    def test_update_custodian_algo_instructions(self):
+        m = self._v2("put", lambda a: a.update_custodian_algo_instructions(5, 9, {"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian/5/CustodianAlgoInstructions/9"
+
+    def test_delete_custodian_algo_instructions(self):
+        m = self._v2("delete", lambda a: a.delete_custodian_algo_instructions(5, 9))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/Custodian/5/CustodianAlgoInstructions/9"
+
+    def test_get_trade_execution_sftp_config(self):
+        m = self._v2("get", lambda a: a.get_trade_execution_sftp_config(2))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/tradeExecutionTypes/2/sftpConfig"
+
+    def test_update_trade_execution_sftp_config(self):
+        m = self._v2("put", lambda a: a.update_trade_execution_sftp_config(2, {"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Admin/tradeExecutionTypes/2/sftpConfig"
+
+    def test_cancel_analytics(self):
+        m = self._v2("post", lambda a: a.cancel_analytics())
+        assert m.call_args.args[0] == f"{V2_BASE}/Analytics/Cancel"
+
+    def test_portfolios_analytics_status(self):
+        m = self._v2("post", lambda a: a.get_portfolios_analytics_status([1]))
+        assert m.call_args.args[0] == f"{V2_BASE}/Analytics/GetPortfoliosAnalyticsStatus"
+
+    def test_reset_analytics_run_history(self):
+        m = self._v2("get", lambda a: a.reset_analytics_run_history())
+        assert m.call_args.args[0] == f"{V2_BASE}/Analytics/ResetAnalyticsRunHistory"
+
+    def test_run_analytics_v2(self):
+        m = self._v2("post", lambda a: a.run_analytics_v2({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Analytics/RunAnalytics"
+
+    def test_update_run_analytics_config(self):
+        m = self._v2("put", lambda a: a.update_run_analytics_config(7, {"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Analytics/RunAnalyticsConfig/7"
+
+    def test_update_analytics_status(self):
+        m = self._v2("post", lambda a: a.update_analytics_status({"x": 1}))
+        assert m.call_args.args[0] == f"{V2_BASE}/Analytics/StatusUpdate"
+
+
+class TestEclipseV1TradeToolAdminBatch17:
+    """v1 TradeTool reference/generate/TLH + Admin token (batch 17)."""
+
+    def _v1(self, verb, fn):
+        api = _eclipse_v1()
+        m = _mock_get([]) if verb == "get" else _mock_post({})
+        with patch(f"requests.{verb}", m):
+            fn(api)
+        return m
+
+    def test_priority_rankings(self):
+        m = self._v1("get", lambda a: a.get_trade_priority_rankings())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/priorityrankings"
+
+    def test_tactical_rebalance_cash_protection(self):
+        m = self._v1("get", lambda a: a.get_tactical_rebalance_cash_protection())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/tacticalRebalanceCashProtection"
+
+    def test_allow_wash_sales(self):
+        m = self._v1("get", lambda a: a.get_allow_wash_sales_options())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/allowwashsales"
+
+    def test_allow_short_term_gains(self):
+        m = self._v1("get", lambda a: a.get_allow_short_term_gains_options())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/allowshorttermgains"
+
+    def test_trade_side(self):
+        m = self._v1("get", lambda a: a.get_trade_side_options())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/tradeside"
+
+    def test_tlh_gainloss_options(self):
+        m = self._v1("get", lambda a: a.get_tlh_gainloss_options())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/taxLossHarvesting/gainloss/options"
+
+    def test_tlh_sign_options(self):
+        m = self._v1("get", lambda a: a.get_tlh_sign_options())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/taxLossHarvesting/sign/options"
+
+    def test_tlh_term_options(self):
+        m = self._v1("get", lambda a: a.get_tlh_term_options())
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/taxLossHarvesting/term/options"
+
+    def test_generate_trade_instance(self):
+        m = self._v1("post", lambda a: a.generate_trade_instance({"isViewOnly": True}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/tradeInstance/action/generateinstance"
+
+    def test_generate_prorated_cash_trade(self):
+        m = self._v1("post", lambda a: a.generate_prorated_cash_trade({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/proratedcash/action/generatetrade"
+
+    def test_generate_raise_cash_trade(self):
+        m = self._v1("post", lambda a: a.generate_raise_cash_trade({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/raisecash/action/generatetrade"
+
+    def test_auto_rebalance(self):
+        m = self._v1("post", lambda a: a.auto_rebalance({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/rebalancer/action/autoRebalance"
+
+    def test_generate_global_trade(self):
+        m = self._v1("post", lambda a: a.generate_global_trade({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/globaltrades/action/generateTrade"
+
+    def test_deserialize_global_trade(self):
+        m = self._v1("post", lambda a: a.deserialize_global_trade({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/globaltrades/action/deserialize"
+
+    def test_generate_liquidate_trade(self):
+        m = self._v1("post", lambda a: a.generate_liquidate_trade({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/liquidate/generateTrade"
+
+    def test_deserialize_ticker_swap(self):
+        m = self._v1("post", lambda a: a.deserialize_ticker_swap({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/tickerswap/action/deserialize"
+
+    def test_generate_trade_to_target(self):
+        m = self._v1("post", lambda a: a.generate_trade_to_target({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/tradetotarget/action/generateTrade"
+
+    def test_deserialize_trade_to_target(self):
+        m = self._v1("post", lambda a: a.deserialize_trade_to_target({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/tradetotarget/action/deserialize"
+
+    def test_upload_trade_file(self):
+        m = self._v1("post", lambda a: a.upload_trade_file({"x": 1}, is_sleeve=True))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/uploadfile"
+        assert m.call_args.kwargs["params"] == {"isSleeve": "true"}
+
+    def test_create_tlh_trade(self):
+        m = self._v1("post", lambda a: a.create_tlh_trade({"x": 1}))
+        assert m.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/createTLHTrade"
+        )
+
+    def test_create_tlh_trade_batch(self):
+        m = self._v1("post", lambda a: a.create_tlh_trade_batch({"x": 1}))
+        assert m.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/createTLHTradeBatchId"
+        )
+
+    def test_create_tlh_trade_generic(self):
+        m = self._v1("post", lambda a: a.create_tlh_trade_generic({"x": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/tradetool/taxLossHarvesting/action/createTrade"
+
+    def test_search_tlh_securities(self):
+        m = self._v1("post", lambda a: a.search_tlh_securities({"x": 1}))
+        assert m.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/searchTLHsecurity"
+        )
+
+    def test_validate_tlh_securities(self):
+        m = self._v1("post", lambda a: a.validate_tlh_securities({"x": 1}))
+        assert m.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/validateTLHSecurities"
+        )
+
+    def test_validate_buy_preferred_tlh_securities(self):
+        m = self._v1("post", lambda a: a.validate_buy_preferred_tlh_securities({"x": 1}))
+        assert m.call_args.args[0] == (
+            f"{V1_BASE}/tradetool/taxLossHarvesting/action/validateBuyPreferredTHSecurities"
+        )
+
+    def test_get_firm_token(self):
+        m = self._v1("post", lambda a: a.get_firm_token({"firmId": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/admin/token/firm"
+
+    def test_get_firm_token_by_id(self):
+        m = self._v1("get", lambda a: a.get_firm_token_by_id(5))
+        assert m.call_args.args[0] == f"{V1_BASE}/admin/token/firm/5"
+
+    def test_login_as(self):
+        m = self._v1("post", lambda a: a.login_as({"userId": 1}))
+        assert m.call_args.args[0] == f"{V1_BASE}/admin/token/loginas"
+
+    def test_revert_login_as(self):
+        m = self._v1("get", lambda a: a.revert_login_as())
+        assert m.call_args.args[0] == f"{V1_BASE}/admin/token/loginas/revert"
+
+    def test_logout(self):
+        m = self._v1("get", lambda a: a.logout())
+        assert m.call_args.args[0] == f"{V1_BASE}/admin/logout"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1545,3 +1545,29 @@ class TestEclipseCoverageBatch16Sweep:
             pytest.skip("no accounts")
         result = eclipse_client.v1.get_account_portfolio_id_by_firm(accts[0]["id"], 1)
         assert isinstance(result, (list, dict, int))
+
+
+class TestEclipseV1TradeToolRefBatch17:
+    """Live smoke for v1 tradetool reference reads (batch 17).
+
+    Generate/TLH-action and admin-token endpoints are mutating/sensitive, so
+    they are unit-tested only.
+    """
+
+    def test_priority_rankings(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_trade_priority_rankings(), list)
+
+    def test_allow_wash_sales(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_allow_wash_sales_options(), list)
+
+    def test_allow_short_term_gains(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_allow_short_term_gains_options(), list)
+
+    def test_trade_side(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_trade_side_options(), list)
+
+    def test_tlh_gainloss_options(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_tlh_gainloss_options(), (list, dict))
+
+    def test_tactical_rebalance_cash_protection(self, eclipse_client):
+        assert isinstance(eclipse_client.v1.get_tactical_rebalance_cash_protection(), (list, dict))


### PR DESCRIPTION
~50 methods (20 v2 + 30 v1) completing the tradetool, admin (custodian/execution + token), and analytics namespaces across both surfaces. No trade approval. Trade-generation endpoints stage trades (pass isViewOnly in body for preview). Reference reads live-verified (8 v1 tradetool option/ranking reads); generate/mutating/token endpoints unit-tested only. 515 unit + 6 live pass; ruff clean. Version 2.17.0 -> 2.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)