### PR TITLE
Fix version drift: pyproject -> 2.20.0 + consistency guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.18.0"
+version = "2.20.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3975,3 +3975,20 @@ class TestApiReferenceDoc:
         text = ref.read_text()
         for cls in ("OrionAPI", "EclipseV1", "EclipseV2", "Eclipse"):
             assert f"## {cls}" in text
+
+
+class TestVersionConsistency:
+    """__version__ and pyproject.toml version must match (guards release drift)."""
+
+    def test_versions_match(self):
+        import re
+        from pathlib import Path
+
+        import orionapi
+
+        pyproject = (Path(__file__).resolve().parent.parent / "pyproject.toml").read_text()
+        m = re.search(r'^version = "([^"]+)"', pyproject, re.M)
+        assert m, "version not found in pyproject.toml"
+        assert m.group(1) == orionapi.__version__, (
+            f"pyproject {m.group(1)} != __version__ {orionapi.__version__}"
+        )


### PR DESCRIPTION
pyproject.toml lagged at 2.18.0 while __init__ was 2.20.0 (the 2.19.0/2.20.0 bumps missed pyproject). Syncs pyproject to 2.20.0 and adds a test asserting __version__ matches pyproject version. Required before releasing 2.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)