### PR TITLE
Add v1 get_instance_trades + simplify cleanup (2.21.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.20.0"
+__version__ = "2.21.0"
 
 import logging
 import re
@@ -4243,6 +4243,24 @@ class EclipseV1(EclipseBase):
             raise ValueError("instance_id must be a positive integer")
 
         res = self.api_request(f"{self.base_url}/tradeorder/instances/{instance_id}/tradeLogs")
+        return res.json()
+
+    def get_instance_trades(self, instance_id, status=None):
+        """Get the trades belonging to a trade instance.
+
+        Args:
+            instance_id: Trade instance ID
+            status: Optional status filter, "open" or "closed" (maps to ``status``)
+
+        Returns:
+            list: Trade dicts for the instance
+        """
+        params = {}
+        if status is not None:
+            params["status"] = status
+        res = self.api_request(
+            f"{self.base_url}/tradeorder/instances/{instance_id}/trades", params=params
+        )
         return res.json()
 
     def get_trade_log_detail(self, log_id):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.20.0"
+version = "2.21.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/scripts/gen_api_reference.py
+++ b/scripts/gen_api_reference.py
@@ -9,7 +9,6 @@ import re
 import orionapi
 
 CLASSES = ["OrionAPI", "EclipseV1", "EclipseV2", "Eclipse"]
-SRC = inspect.getsource(orionapi)
 
 
 def endpoint_for(func):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3992,3 +3992,23 @@ class TestVersionConsistency:
         assert m.group(1) == orionapi.__version__, (
             f"pyproject {m.group(1)} != __version__ {orionapi.__version__}"
         )
+
+
+class TestEclipseV1InstanceTrades:
+    """v1 get_instance_trades — flips the MCP get_instance_trades off the escape hatch."""
+
+    def test_instance_trades_no_filter(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_instance_trades(5165)
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/tradeorder/instances/5165/trades"
+        assert mock_get.call_args.kwargs["params"] == {}
+
+    def test_instance_trades_status_filter(self):
+        api = _eclipse_v1()
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_instance_trades(5165, status="open")
+        assert mock_get.call_args.args[0] == f"{V1_BASE}/tradeorder/instances/5165/trades"
+        assert mock_get.call_args.kwargs["params"] == {"status": "open"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1571,3 +1571,18 @@ class TestEclipseV1TradeToolRefBatch17:
 
     def test_tactical_rebalance_cash_protection(self, eclipse_client):
         assert isinstance(eclipse_client.v1.get_tactical_rebalance_cash_protection(), (list, dict))
+
+
+class TestEclipseV1InstanceTrades:
+    """Live smoke for v1 get_instance_trades (fills the MCP delegation-map gap)."""
+
+    def test_instance_trades(self, eclipse_client):
+        from datetime import datetime, timedelta
+
+        ed = datetime.now().strftime("%Y-%m-%d")
+        sd = (datetime.now() - timedelta(days=120)).strftime("%Y-%m-%d")
+        instances = eclipse_client.v1.get_trade_instances(sd, ed, normalize=False)
+        if not instances:
+            pytest.skip("no trade instances in window")
+        result = eclipse_client.v1.get_instance_trades(instances[0]["id"])
+        assert isinstance(result, list)


### PR DESCRIPTION
**Fills the MCP delegation-map gap:** adds `EclipseV1.get_instance_trades(instance_id, status=None)` → `GET /tradeorder/instances/{id}/trades?status={open/closed}` — the one endpoint the DeeSam Eclipse MCP still reached via the raw `api_request` escape hatch. The MCP's `get_instance_trades` can now flip to the named method. Live-verified (status=closed → 524 trades).

**/simplify pass (whole codebase):** 4 review agents run. Applied the one clearly-safe contained fix — removed dead `SRC = inspect.getsource(...)` in scripts/gen_api_reference.py. Skipped the larger findings (params-dict/`str(bool).lower()` boilerplate, per-method thin wrappers) as intentional design (discoverability + generated docs + typed returns) not worth high-churn changes to working, tested, released code; left the unused public `MODEL_TYPE_SECURITY_SET` constant to avoid an external-importer break.

522 unit + 1 live pass; ruff clean. Version 2.20.0 -> 2.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)