### PR TITLE
Make api_request timeout configurable per-client (2.22.0)

### DIFF
--- a/orionapi/__init__.py
+++ b/orionapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.21.0"
+__version__ = "2.22.0"
 
 import logging
 import re
@@ -187,17 +187,20 @@ class BaseAPI:
 
     base_url = None
 
-    def __init__(self, rate_limit=10, verify_ssl=True, ca_bundle=None):
+    def __init__(self, rate_limit=10, verify_ssl=True, ca_bundle=None, timeout=30):
         """Initialize base API with rate limiting and SSL configuration.
 
         Args:
             rate_limit: Maximum API calls per second (default 10, set to 0 to disable)
             verify_ssl: Verify SSL certificates (default True)
             ca_bundle: Path to custom CA bundle file (optional)
+            timeout: Default per-request timeout in seconds (default 30). Used by
+                :meth:`api_request` when a call doesn't pass its own ``timeout``.
         """
         self._rate_limiter = RateLimiter(calls_per_second=rate_limit)
         self.verify_ssl = verify_ssl
         self.ca_bundle = ca_bundle
+        self.timeout = timeout
         # RLock so subclasses can hold the lock across an internal call
         # path that re-enters auth-header construction.
         self._token_lock = threading.RLock()
@@ -249,7 +252,7 @@ class BaseAPI:
 
         return data
 
-    def api_request(self, url, req_func=None, timeout=30, **kwargs):
+    def api_request(self, url, req_func=None, timeout=None, **kwargs):
         """Make an authenticated API request with error handling.
 
         Args:
@@ -258,7 +261,9 @@ class BaseAPI:
                 Defaults to ``requests.get``. Resolved at call time (not bound as a
                 default argument) so that patching ``requests.get`` in tests takes
                 effect for GET methods.
-            timeout: Request timeout in seconds (default 30)
+            timeout: Per-call request timeout in seconds. When None (default), falls
+                back to the client's ``self.timeout`` (set in the constructor,
+                default 30).
             **kwargs: Additional arguments passed to the request
 
         Returns:
@@ -271,6 +276,8 @@ class BaseAPI:
         """
         if req_func is None:
             req_func = requests.get
+        if timeout is None:
+            timeout = self.timeout
 
         # Apply rate limiting
         self._rate_limiter.wait()
@@ -338,8 +345,12 @@ class OrionAPI(BaseAPI):
         'user@example.com'
     """
 
-    def __init__(self, usr=None, pwd=None, rate_limit=10, verify_ssl=True, ca_bundle=None):
-        super().__init__(rate_limit=rate_limit, verify_ssl=verify_ssl, ca_bundle=ca_bundle)
+    def __init__(
+        self, usr=None, pwd=None, rate_limit=10, verify_ssl=True, ca_bundle=None, timeout=30
+    ):
+        super().__init__(
+            rate_limit=rate_limit, verify_ssl=verify_ssl, ca_bundle=ca_bundle, timeout=timeout
+        )
         self.token = None
         self.base_url = "https://api.orionadvisor.com/api/v1/"
         self._custom_field_cache = {}
@@ -2124,8 +2135,11 @@ class EclipseBase(BaseAPI):
         rate_limit=10,
         verify_ssl=True,
         ca_bundle=None,
+        timeout=30,
     ):
-        super().__init__(rate_limit=rate_limit, verify_ssl=verify_ssl, ca_bundle=ca_bundle)
+        super().__init__(
+            rate_limit=rate_limit, verify_ssl=verify_ssl, ca_bundle=ca_bundle, timeout=timeout
+        )
         self.eclipse_token = None
         self.base_url = "https://api.orioneclipse.com/v1"
         # The v2 surface lives at the host root (/api/v2/...), NOT under /v1.
@@ -10835,6 +10849,7 @@ class Eclipse(EclipseBase):
         rate_limit=10,
         verify_ssl=True,
         ca_bundle=None,
+        timeout=30,
     ):
         super().__init__(
             usr=usr,
@@ -10844,6 +10859,7 @@ class Eclipse(EclipseBase):
             rate_limit=rate_limit,
             verify_ssl=verify_ssl,
             ca_bundle=ca_bundle,
+            timeout=timeout,
         )
         # Share the single authenticated token with both sub-clients (no re-login).
         sub_kwargs = {
@@ -10851,6 +10867,7 @@ class Eclipse(EclipseBase):
             "rate_limit": rate_limit,
             "verify_ssl": verify_ssl,
             "ca_bundle": ca_bundle,
+            "timeout": timeout,
         }
         self.v1 = EclipseV1(**sub_kwargs)
         self.v2 = EclipseV2(**sub_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orionapi"
-version = "2.21.0"
+version = "2.22.0"
 description = "A python interface for the Orion Advisors platform web API"
 authors = ["spencerogden-dsam <67068943+spencerogden-dsam@users.noreply.github.com>"]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -4012,3 +4012,48 @@ class TestEclipseV1InstanceTrades:
             api.get_instance_trades(5165, status="open")
         assert mock_get.call_args.args[0] == f"{V1_BASE}/tradeorder/instances/5165/trades"
         assert mock_get.call_args.kwargs["params"] == {"status": "open"}
+
+
+class TestConfigurableTimeout:
+    """api_request timeout defaults to self.timeout, settable in constructors (2.22.0)."""
+
+    def test_default_timeout_is_30(self):
+        api = _eclipse_v1()
+        assert api.timeout == 30
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_account_filters()
+        assert mock_get.call_args.kwargs["timeout"] == 30
+
+    def test_constructor_timeout_propagates_to_requests(self):
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="u", pwd="p", timeout=120)
+        api.eclipse_token = "tok"
+        assert api.timeout == 120
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            api.get_account_filters()
+        assert mock_get.call_args.kwargs["timeout"] == 120
+
+    def test_per_call_timeout_overrides_instance(self):
+        with patch.object(EclipseV1, "login"):
+            api = EclipseV1(usr="u", pwd="p", timeout=120)
+        api.eclipse_token = "tok"
+        mock_get = _mock_get([])
+        with patch("requests.get", mock_get):
+            # api_request honors an explicit per-call timeout over self.timeout
+            api.api_request(f"{api.base_url}/x", timeout=5)
+        assert mock_get.call_args.kwargs["timeout"] == 5
+
+    def test_orion_constructor_timeout(self):
+        with patch.object(OrionAPI, "login"):
+            api = OrionAPI(usr="u", pwd="p", timeout=90)
+        assert api.timeout == 90
+
+    def test_eclipse_unifier_propagates_timeout_to_subclients(self):
+        from orionapi import Eclipse
+
+        api = Eclipse(eclipse_token="tok", timeout=75)
+        assert api.timeout == 75
+        assert api.v1.timeout == 75
+        assert api.v2.timeout == 75


### PR DESCRIPTION
api_request hardcoded a 30s timeout. Adds a `timeout` constructor param (default 30) to BaseAPI / OrionAPI / EclipseBase / EclipseV1 / EclipseV2 / Eclipse (the unifier forwards it to its .v1/.v2 sub-clients). `api_request` now defaults `timeout=None` → falls back to `self.timeout`; an explicit per-call `timeout=` still overrides. Fully backward compatible (default still 30s). 563 unit tests pass incl. 5 new timeout tests; ruff clean. Version 2.21.0 -> 2.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)